### PR TITLE
fix: leave unresolvable env var expressions untouched in config

### DIFF
--- a/src/config/loadConfig.test.ts
+++ b/src/config/loadConfig.test.ts
@@ -92,7 +92,7 @@ describe('loadConfig', () => {
     }
   });
 
-  it('throws for missing env var in config', async () => {
+  it('leaves unresolvable ${...} expressions in config untouched', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'jw-cfg-'));
     const cfgPath = join(dir, 'jeeves-watcher.config.json');
     await writeFile(
@@ -104,7 +104,8 @@ describe('loadConfig', () => {
       'utf8',
     );
 
-    await expect(loadConfig(cfgPath)).rejects.toThrow(/MISSING_JW_VAR_99/);
+    const config = await loadConfig(cfgPath);
+    expect(config.embedding.apiKey).toBe('${MISSING_JW_VAR_99}');
   });
 });
 

--- a/src/config/substituteEnvVars.test.ts
+++ b/src/config/substituteEnvVars.test.ts
@@ -38,9 +38,15 @@ describe('substituteEnvVars', () => {
     expect(substituteEnvVars(input)).toEqual(input);
   });
 
-  it('throws for missing env var', () => {
-    expect(() => substituteEnvVars('${MISSING_JW_VAR_XYZ}')).toThrow(
-      /MISSING_JW_VAR_XYZ.*not set/,
+  it('leaves unresolvable ${...} expressions untouched', () => {
+    expect(substituteEnvVars('${MISSING_JW_VAR_XYZ}')).toBe(
+      '${MISSING_JW_VAR_XYZ}',
+    );
+  });
+
+  it('leaves template expressions like ${frontmatter.title} untouched', () => {
+    expect(substituteEnvVars('${frontmatter.title}')).toBe(
+      '${frontmatter.title}',
     );
   });
 });

--- a/src/config/substituteEnvVars.ts
+++ b/src/config/substituteEnvVars.ts
@@ -10,17 +10,12 @@ const ENV_PATTERN = /\$\{([^}]+)\}/g;
  * Replace `${VAR_NAME}` patterns in a string with `process.env.VAR_NAME`.
  *
  * @param value - The string to process.
- * @returns The string with env vars substituted.
- * @throws If a referenced env var is not set.
+ * @returns The string with resolved env vars; unresolvable expressions left untouched.
  */
 function substituteString(value: string): string {
   return value.replace(ENV_PATTERN, (match, varName: string) => {
     const envValue = process.env[varName];
-    if (envValue === undefined) {
-      throw new Error(
-        `Environment variable \${${varName}} referenced in config is not set.`,
-      );
-    }
+    if (envValue === undefined) return match;
     return envValue;
   });
 }


### PR DESCRIPTION
Closes #8.

Env var substitution now leaves unresolvable `\` expressions in place instead of throwing. This allows `\` and similar template expressions in inference rule `set` values to coexist with `\` env var references.

All stan checks green.