### PR TITLE
fix: remove shebang from ESM CLI output

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -133,7 +133,10 @@ const config: RollupOptions[] = [
         dir: `${outputPath}/cli/${c}`,
         extend: true,
         format: 'esm',
-        banner: '#!/usr/bin/env node',
+        // No shebang banner: npm's bin wrapper handles invocation on all
+        // platforms, and Node v24's ESM parser does not strip shebangs,
+        // breaking direct `node.exe <file>` calls (e.g. NSSM on Windows).
+        // See: https://github.com/karmaniverous/jeeves-watcher/issues/15
       },
     ],
   })),

--- a/src/cli/jeeves-watcher/index.ts
+++ b/src/cli/jeeves-watcher/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * @module cli/jeeves-watcher
  *


### PR DESCRIPTION
Closes #15.

Removes the `#!/usr/bin/env node` shebang from both the source file and the rollup banner. Node v24's ESM parser doesn't strip shebangs, so direct `node.exe <file>` invocations (e.g. via NSSM on Windows) fail with a parse error.

The shebang is unnecessary: npm's generated `.cmd`/shell wrapper already handles invocation on all platforms.

All stan checks green.