### PR TITLE
fix: chokidar v5 Windows glob + ignored pattern resolution

### DIFF
--- a/src/watcher/globToDir.test.ts
+++ b/src/watcher/globToDir.test.ts
@@ -9,6 +9,7 @@ import {
   buildGlobMatcher,
   deduplicateRoots,
   globRoot,
+  resolveIgnored,
   resolveWatchPaths,
 } from './globToDir';
 
@@ -104,5 +105,78 @@ describe('resolveWatchPaths', () => {
     expect(matches('j:/domains/jira/WEB-1.json')).toBe(true);
     expect(matches('j:/config/watcher.json')).toBe(true);
     expect(matches('j:/domains/file.py')).toBe(false);
+  });
+});
+
+describe('resolveIgnored', () => {
+  it('converts glob strings to matcher functions', () => {
+    const resolved = resolveIgnored(['**/node_modules/**']);
+    expect(resolved).toHaveLength(1);
+    expect(typeof resolved[0]).toBe('function');
+
+    const matcher = resolved[0] as (path: string) => boolean;
+    expect(matcher('j:/domains/projects/foo/node_modules/bar/baz.js')).toBe(
+      true,
+    );
+    expect(matcher('j:/domains/projects/foo/src/index.ts')).toBe(false);
+  });
+
+  it('matches node_modules at any depth', () => {
+    const [matcher] = resolveIgnored(['**/node_modules/**']) as ((
+      path: string,
+    ) => boolean)[];
+    expect(
+      matcher('j:/jeeves/temp/node_modules/@types/node/net.d.ts'),
+    ).toBe(true);
+    expect(
+      matcher(
+        'j:/domains/projects/tiny-poems/book/node_modules/puppeteer-core/lib/foo.js',
+      ),
+    ).toBe(true);
+    expect(matcher('j:/domains/projects/tiny-poems/src/index.ts')).toBe(false);
+  });
+
+  it('normalizes backslashes before matching', () => {
+    const [matcher] = resolveIgnored(['**/node_modules/**']) as ((
+      path: string,
+    ) => boolean)[];
+    expect(
+      matcher('j:\\domains\\projects\\foo\\node_modules\\bar\\baz.js'),
+    ).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    const [matcher] = resolveIgnored(['**/Node_Modules/**']) as ((
+      path: string,
+    ) => boolean)[];
+    expect(matcher('J:/Domains/foo/node_modules/bar.js')).toBe(true);
+  });
+
+  it('passes through function entries unchanged', () => {
+    const fn = (path: string) => path.includes('skip');
+    const resolved = resolveIgnored([fn as unknown as string]);
+    expect(resolved[0]).toBe(fn);
+  });
+
+  it('passes through RegExp entries unchanged', () => {
+    const re = /\.tmp$/;
+    const resolved = resolveIgnored([re as unknown as string]);
+    expect(resolved[0]).toBe(re);
+  });
+
+  it('handles mixed glob patterns', () => {
+    const resolved = resolveIgnored([
+      '**/node_modules/**',
+      '**/.git/**',
+      '**/package-lock.json',
+    ]);
+    expect(resolved).toHaveLength(3);
+    resolved.forEach((m) => expect(typeof m).toBe('function'));
+
+    const matchers = resolved as ((path: string) => boolean)[];
+    expect(matchers[0]('j:/foo/node_modules/bar.js')).toBe(true);
+    expect(matchers[1]('j:/foo/.git/config')).toBe(true);
+    expect(matchers[2]('j:/foo/bar/package-lock.json')).toBe(true);
+    expect(matchers[2]('j:/foo/bar/package.json')).toBe(false);
   });
 });

--- a/src/watcher/globToDir.ts
+++ b/src/watcher/globToDir.ts
@@ -83,3 +83,33 @@ export function resolveWatchPaths(globs: string[]): {
   const matches = buildGlobMatcher(globs);
   return { roots, matches };
 }
+
+/**
+ * Convert ignored glob patterns to picomatch matcher functions.
+ *
+ * Chokidar v5 replaced the external `anymatch` dependency with an inline
+ * implementation that does **exact string equality** for string matchers,
+ * breaking glob-based `ignored` patterns. This function converts glob strings
+ * to picomatch functions that chokidar's `createPattern` passes through
+ * unchanged (`typeof matcher === 'function'`).
+ *
+ * Non-string entries (functions, RegExps) are passed through as-is.
+ *
+ * @param ignored - Array of ignored patterns (globs, functions, RegExps).
+ * @returns Array with glob strings replaced by picomatch matcher functions.
+ */
+export function resolveIgnored(
+  ignored: (string | RegExp | ((path: string) => boolean))[],
+): (string | RegExp | ((path: string) => boolean))[] {
+  return ignored.map((entry) => {
+    if (typeof entry !== 'string') return entry;
+    // If the string contains glob characters, convert to a picomatch function.
+    // Literal strings (exact paths) are also converted for consistent matching.
+    const normalizedPattern = entry.replace(/\\/g, '/');
+    const matcher = picomatch(normalizedPattern, { dot: true, nocase: true });
+    return (filePath: string) => {
+      const normalized = filePath.replace(/\\/g, '/');
+      return matcher(normalized);
+    };
+  });
+}

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -11,7 +11,7 @@ import { SystemHealth, type SystemHealthOptions } from '../health';
 import type { DocumentProcessor } from '../processor';
 import type { EventQueue } from '../queue';
 import { normalizeError } from '../util/normalizeError';
-import { resolveWatchPaths } from './globToDir';
+import { resolveIgnored, resolveWatchPaths } from './globToDir';
 
 /**
  * Options for {@link FileSystemWatcher} beyond basic config.
@@ -84,8 +84,15 @@ export class FileSystemWatcher {
     const { roots, matches } = resolveWatchPaths(this.config.paths);
     this.globMatches = matches;
 
+    // Chokidar v5's inline anymatch does exact string equality for string
+    // matchers, breaking glob-based ignored patterns. Convert to picomatch
+    // functions that chokidar passes through as-is.
+    const ignored = this.config.ignored
+      ? resolveIgnored(this.config.ignored as string[])
+      : undefined;
+
     this.watcher = chokidar.watch(roots, {
-      ignored: this.config.ignored,
+      ignored,
       usePolling: this.config.usePolling,
       interval: this.config.pollIntervalMs,
       awaitWriteFinish: this.config.stabilityThresholdMs


### PR DESCRIPTION
## Summary

Fixes two chokidar v5 regressions on Windows:

1. **Watch path globs** (commit 1c4200e): Chokidar v5 removed glob support, silently treating glob patterns as literal strings. Added \esolveWatchPaths()\ to extract directory roots for chokidar and filter events through picomatch.

2. **Ignored glob patterns** (commit 71ac592): Chokidar v5 replaced the external \nymatch\ dependency with an inline implementation that does **exact string equality** for string matchers, silently breaking all glob-based \ignored\ patterns (\**/node_modules/**\, \**/.git/**\, etc.). Added \esolveIgnored()\ to convert ignored glob strings to picomatch matcher functions.

Also includes a cross-drive gitignore fix for \path.relative()\ on Windows.

## Impact

Without this fix, the watcher was indexing ~99K files from \.deleted/\ directories and ~40K files from \
ode_modules/\ — all junk that the \ignored\ config should have excluded.

## Testing

- 21 unit tests for glob resolution (14 existing + 7 new for \esolveIgnored\)
- Gitignore cross-drive fix tested
- Live-tested watcher startup on J:\ drive

Closes #25