### PR TITLE
fix: resolve file path references in named maps config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -122,7 +122,7 @@
       ]
     },
     "maps": {
-      "description": "Reusable named JsonMap transformations.",
+      "description": "Reusable named JsonMap transformations (inline definition or .json file path resolved relative to config directory).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema51"
@@ -597,7 +597,14 @@
         "type": "string"
       },
       "additionalProperties": {
-        "$ref": "#/definitions/__schema48"
+        "anyOf": [
+          {
+            "$ref": "#/definitions/__schema48"
+          },
+          {
+            "type": "string"
+          }
+        ]
       }
     },
     "__schema52": {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import type { JsonMapMap } from '@karmaniverous/jsonmap';
 import { cosmiconfig } from 'cosmiconfig';
 import { ZodError } from 'zod';
 
@@ -56,6 +60,20 @@ export async function loadConfig(
 
   try {
     const validated = jeevesWatcherConfigSchema.parse(result.config);
+
+    // Resolve file-path map references relative to config directory.
+    // After this block, all map values are inline JsonMapMap objects.
+    if (validated.maps) {
+      const configDir = dirname(result.filepath);
+      for (const [name, value] of Object.entries(validated.maps)) {
+        if (typeof value === 'string') {
+          const mapPath = resolve(configDir, value);
+          const raw = readFileSync(mapPath, 'utf-8');
+          validated.maps[name] = JSON.parse(raw) as JsonMapMap;
+        }
+      }
+    }
+
     const withDefaults = applyDefaults(validated);
     return substituteEnvVars(withDefaults);
   } catch (error) {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -252,11 +252,13 @@ export const jeevesWatcherConfigSchema = z.object({
     .array(inferenceRuleSchema)
     .optional()
     .describe('Rules for inferring metadata from file attributes.'),
-  /** Reusable named JsonMap transformations. */
+  /** Reusable named JsonMap transformations (inline objects or .json file paths). */
   maps: z
-    .record(z.string(), jsonMapMapSchema)
+    .record(z.string(), jsonMapMapSchema.or(z.string()))
     .optional()
-    .describe('Reusable named JsonMap transformations.'),
+    .describe(
+      'Reusable named JsonMap transformations (inline definition or .json file path resolved relative to config directory).',
+    ),
   /** Reusable named Handlebars templates (inline strings or .hbs/.handlebars file paths). */
   templates: z
     .record(z.string(), z.string())

--- a/src/watcher/globToDir.test.ts
+++ b/src/watcher/globToDir.test.ts
@@ -125,9 +125,9 @@ describe('resolveIgnored', () => {
     const [matcher] = resolveIgnored(['**/node_modules/**']) as ((
       path: string,
     ) => boolean)[];
-    expect(
-      matcher('j:/jeeves/temp/node_modules/@types/node/net.d.ts'),
-    ).toBe(true);
+    expect(matcher('j:/jeeves/temp/node_modules/@types/node/net.d.ts')).toBe(
+      true,
+    );
     expect(
       matcher(
         'j:/domains/projects/tiny-poems/book/node_modules/puppeteer-core/lib/foo.js',
@@ -171,7 +171,9 @@ describe('resolveIgnored', () => {
       '**/package-lock.json',
     ]);
     expect(resolved).toHaveLength(3);
-    resolved.forEach((m) => expect(typeof m).toBe('function'));
+    resolved.forEach((m) => {
+      expect(typeof m).toBe('function');
+    });
 
     const matchers = resolved as ((path: string) => boolean)[];
     expect(matchers[0]('j:/foo/node_modules/bar.js')).toBe(true);

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -88,7 +88,7 @@ export class FileSystemWatcher {
     // matchers, breaking glob-based ignored patterns. Convert to picomatch
     // functions that chokidar passes through as-is.
     const ignored = this.config.ignored
-      ? resolveIgnored(this.config.ignored as string[])
+      ? resolveIgnored(this.config.ignored)
       : undefined;
 
     this.watcher = chokidar.watch(roots, {


### PR DESCRIPTION
The maps schema only accepted inline JsonMap objects, silently stripping string file paths during Zod validation. Updated schema to accept jsonMapMapSchema | string, and added file path resolution in loadConfig that loads .json files relative to the config directory.