### PR TITLE
feat: custom JsonMap lib functions via mapHelpers

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -145,11 +145,19 @@
         }
       ]
     },
+    "mapHelpers": {
+      "description": "Custom JsonMap lib function registration.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema55"
+        }
+      ]
+    },
     "logging": {
       "description": "Logging configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema55"
+          "$ref": "#/definitions/__schema57"
         }
       ]
     },
@@ -157,7 +165,7 @@
       "description": "Timeout in milliseconds for graceful shutdown.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema58"
+          "$ref": "#/definitions/__schema60"
         }
       ]
     },
@@ -165,7 +173,7 @@
       "description": "Maximum consecutive system-level failures before triggering fatal error. Default: Infinity.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema59"
+          "$ref": "#/definitions/__schema61"
         }
       ]
     },
@@ -173,7 +181,7 @@
       "description": "Maximum backoff delay in milliseconds for system errors. Default: 60000.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema60"
+          "$ref": "#/definitions/__schema62"
         }
       ]
     }
@@ -638,11 +646,30 @@
     "__schema55": {
       "type": "object",
       "properties": {
+        "paths": {
+          "description": "File paths to JS modules exporting functions to merge into the JsonMap lib.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema56"
+            }
+          ]
+        }
+      }
+    },
+    "__schema56": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "__schema57": {
+      "type": "object",
+      "properties": {
         "level": {
           "description": "Logging level (trace, debug, info, warn, error, fatal).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema56"
+              "$ref": "#/definitions/__schema58"
             }
           ]
         },
@@ -650,25 +677,25 @@
           "description": "Path to log file (logs to stdout if omitted).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema57"
+              "$ref": "#/definitions/__schema59"
             }
           ]
         }
       }
     },
-    "__schema56": {
-      "type": "string"
-    },
-    "__schema57": {
-      "type": "string"
-    },
     "__schema58": {
-      "type": "number"
+      "type": "string"
     },
     "__schema59": {
-      "type": "number"
+      "type": "string"
     },
     "__schema60": {
+      "type": "number"
+    },
+    "__schema61": {
+      "type": "number"
+    },
+    "__schema62": {
       "type": "number"
     }
   }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -12,6 +12,7 @@ import type { JeevesWatcherConfig } from '../config/types';
 import { GitignoreFilter } from '../gitignore';
 import type { DocumentProcessor } from '../processor';
 import type { EventQueue } from '../queue';
+import { loadCustomMapHelpers } from '../rules/apply';
 import { buildTemplateEngine } from '../templates';
 import { normalizeError } from '../util/normalizeError';
 import type { FileSystemWatcher } from '../watcher';
@@ -88,6 +89,12 @@ export class JeevesWatcher {
       configDir,
     );
 
+    // Load custom JsonMap lib functions
+    const customMapLib =
+      this.config.mapHelpers?.paths?.length && configDir
+        ? await loadCustomMapHelpers(this.config.mapHelpers.paths, configDir)
+        : undefined;
+
     const processor = this.factories.createDocumentProcessor(
       {
         metadataDir: this.config.metadataDir ?? '.jeeves-metadata',
@@ -95,6 +102,7 @@ export class JeevesWatcher {
         chunkOverlap: this.config.embedding.chunkOverlap,
         maps: this.config.maps,
         configDir,
+        customMapLib,
       },
       embeddingProvider,
       vectorStore,
@@ -291,7 +299,16 @@ export class JeevesWatcher {
         newConfig.templateHelpers?.paths,
         reloadConfigDir,
       );
-      processor.updateRules(compiledRules, newTemplateEngine);
+
+      const newCustomMapLib =
+        newConfig.mapHelpers?.paths?.length && reloadConfigDir
+          ? await loadCustomMapHelpers(
+              newConfig.mapHelpers.paths,
+              reloadConfigDir,
+            )
+          : undefined;
+
+      processor.updateRules(compiledRules, newTemplateEngine, newCustomMapLib);
 
       logger.info(
         { configPath: this.configPath, rules: compiledRules.length },

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -277,6 +277,19 @@ export const jeevesWatcherConfigSchema = z.object({
     })
     .optional()
     .describe('Custom Handlebars helper registration.'),
+  /** Custom JsonMap lib function registration. */
+  mapHelpers: z
+    .object({
+      /** File paths to custom lib modules (each exports functions to merge into the JsonMap lib). */
+      paths: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'File paths to JS modules exporting functions to merge into the JsonMap lib.',
+        ),
+    })
+    .optional()
+    .describe('Custom JsonMap lib function registration.'),
   /** Logging configuration. */
   logging: loggingConfigSchema.optional().describe('Logging configuration.'),
   /** Timeout in milliseconds for graceful shutdown. */

--- a/src/processor/buildMetadata.ts
+++ b/src/processor/buildMetadata.ts
@@ -53,6 +53,7 @@ export async function buildMergedMetadata(
   logger?: pino.Logger,
   templateEngine?: TemplateEngine,
   configDir?: string,
+  customMapLib?: Record<string, (...args: unknown[]) => unknown>,
 ): Promise<MergedMetadata> {
   const ext = extname(filePath);
   const stats = await stat(filePath);
@@ -74,6 +75,7 @@ export async function buildMergedMetadata(
     logger,
     templateEngine,
     configDir,
+    customMapLib,
   );
 
   // 3. Read enrichment metadata (merge, enrichment wins)

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -35,6 +35,8 @@ export interface ProcessorConfig {
   maps?: Record<string, JsonMapMap>;
   /** Config directory for resolving relative file paths. */
   configDir?: string;
+  /** Custom JsonMap lib functions loaded from mapHelpers config. */
+  customMapLib?: Record<string, (...args: unknown[]) => unknown>;
 }
 
 /**
@@ -43,7 +45,7 @@ export interface ProcessorConfig {
  * Handles extracting text, computing embeddings, and syncing with the vector store.
  */
 export class DocumentProcessor {
-  private readonly config: ProcessorConfig;
+  private config: ProcessorConfig;
   private readonly embeddingProvider: EmbeddingProvider;
   private readonly vectorStore: VectorStoreClient;
   private compiledRules: CompiledRule[];
@@ -95,6 +97,7 @@ export class DocumentProcessor {
           this.logger,
           this.templateEngine,
           this.config.configDir,
+          this.config.customMapLib,
         );
 
       // Use rendered template content if available, otherwise raw extracted text
@@ -250,6 +253,7 @@ export class DocumentProcessor {
         this.logger,
         this.templateEngine,
         this.config.configDir,
+        this.config.customMapLib,
       );
 
       // Update all chunk payloads
@@ -269,23 +273,23 @@ export class DocumentProcessor {
   }
 
   /**
-   * Update compiled inference rules for subsequent file processing.
-   *
-   * @param compiledRules - The newly compiled rules.
-   */
-  /**
-   * Update compiled inference rules and optionally the template engine.
+   * Update compiled inference rules, template engine, and custom map lib.
    *
    * @param compiledRules - The newly compiled rules.
    * @param templateEngine - Optional updated template engine.
+   * @param customMapLib - Optional updated custom JsonMap lib functions.
    */
   updateRules(
     compiledRules: CompiledRule[],
     templateEngine?: TemplateEngine,
+    customMapLib?: Record<string, (...args: unknown[]) => unknown>,
   ): void {
     this.compiledRules = compiledRules;
     if (templateEngine) {
       this.templateEngine = templateEngine;
+    }
+    if (customMapLib !== undefined) {
+      this.config = { ...this.config, customMapLib };
     }
     this.logger.info(
       { rules: compiledRules.length },

--- a/src/rules/apply.ts
+++ b/src/rules/apply.ts
@@ -30,9 +30,25 @@ export interface RuleLogger {
 /**
  * Create the lib object for JsonMap transformations.
  *
+ * @param configDir - Optional config directory for resolving relative file paths in lookups.
  * @returns The lib object.
  */
-function createJsonMapLib() {
+function createJsonMapLib(
+  configDir?: string,
+  customLib?: Record<string, (...args: unknown[]) => unknown>,
+) {
+  // Cache loaded JSON files within a single applyRules invocation.
+  const jsonCache = new Map<string, unknown>();
+
+  const loadJson = (filePath: string): Record<string, unknown> => {
+    const resolvedPath = configDir ? resolve(configDir, filePath) : filePath;
+    if (!jsonCache.has(resolvedPath)) {
+      const raw = readFileSync(resolvedPath, 'utf-8');
+      jsonCache.set(resolvedPath, JSON.parse(raw) as unknown);
+    }
+    return jsonCache.get(resolvedPath) as Record<string, unknown>;
+  };
+
   return {
     split: (str: string, separator: string) => str.split(separator),
     slice: <T>(arr: T[], start: number, end?: number) => arr.slice(start, end),
@@ -41,7 +57,87 @@ function createJsonMapLib() {
     replace: (str: string, search: string | RegExp, replacement: string) =>
       str.replace(search, replacement),
     get: (obj: unknown, path: string) => get(obj, path),
+
+    /**
+     * Load a JSON file (relative to configDir) and look up a value by key,
+     * optionally drilling into a sub-path.
+     *
+     * @param filePath - Path to a JSON file (resolved relative to configDir).
+     * @param key - Top-level key to look up.
+     * @param field - Optional dot-path into the looked-up entry.
+     * @returns The resolved value, or null if not found.
+     */
+    lookupJson: (filePath: string, key: string, field?: string) => {
+      const data = loadJson(filePath);
+      const entry = data[key];
+      if (entry === undefined || entry === null) return null;
+      if (field) return get(entry, field) ?? null;
+      return entry;
+    },
+
+    /**
+     * Map an array of keys through a JSON lookup file, collecting a specific
+     * field from each matching entry. Non-matching keys are silently skipped.
+     * Array-valued fields are flattened into the result.
+     *
+     * @param filePath - Path to a JSON file (resolved relative to configDir).
+     * @param keys - Array of top-level keys to look up.
+     * @param field - Dot-path into each looked-up entry.
+     * @returns Flat array of resolved values.
+     */
+    mapLookup: (filePath: string, keys: unknown[], field: string) => {
+      if (!Array.isArray(keys)) return [];
+      const data = loadJson(filePath);
+      const results: unknown[] = [];
+      for (const k of keys) {
+        if (typeof k !== 'string') continue;
+        const entry = data[k];
+        if (entry === undefined || entry === null) continue;
+        const val = get(entry, field);
+        if (val === undefined || val === null) continue;
+        if (Array.isArray(val)) {
+          for (const item of val) {
+            results.push(item);
+          }
+        } else {
+          results.push(val);
+        }
+      }
+      return results;
+    },
+    ...customLib,
   };
+}
+
+/**
+ * Load custom JsonMap lib functions from file paths.
+ *
+ * Each module should default-export an object of functions,
+ * or use named exports. Only function-valued exports are merged.
+ *
+ * @param paths - File paths to custom lib modules.
+ * @param configDir - Directory to resolve relative paths against.
+ * @returns The merged custom lib functions.
+ */
+export async function loadCustomMapHelpers(
+  paths: string[],
+  configDir: string,
+): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  const merged: Record<string, (...args: unknown[]) => unknown> = {};
+  for (const p of paths) {
+    const resolved = resolve(configDir, p);
+    const mod = (await import(resolved)) as Record<string, unknown>;
+    const fns =
+      typeof mod.default === 'object' && mod.default !== null
+        ? (mod.default as Record<string, unknown>)
+        : mod;
+    for (const [key, val] of Object.entries(fns)) {
+      if (typeof val === 'function') {
+        merged[key] = val as (...args: unknown[]) => unknown;
+      }
+    }
+  }
+  return merged;
 }
 
 /**
@@ -76,10 +172,14 @@ export async function applyRules(
   logger?: RuleLogger,
   templateEngine?: TemplateEngine,
   configDir?: string,
+  customMapLib?: Record<string, (...args: unknown[]) => unknown>,
 ): Promise<ApplyRulesResult> {
   // JsonMap's type definitions expect a generic JsonMapLib shape with unary functions.
   // Our helper functions accept multiple args, which JsonMap supports at runtime.
-  const lib = createJsonMapLib() as unknown as JsonMapLib;
+  const lib = createJsonMapLib(
+    configDir,
+    customMapLib,
+  ) as unknown as JsonMapLib;
   let merged: Record<string, unknown> = {};
   let renderedContent: string | null = null;
   const log: RuleLogger = logger ?? console;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,6 +3,11 @@
  * Inference rule engine: compiles JSON-Schema rules, matches file attributes, resolves templates, and applies JsonMap transforms.
  */
 
-export { applyRules, type ApplyRulesResult, type RuleLogger } from './apply';
+export {
+  applyRules,
+  type ApplyRulesResult,
+  loadCustomMapHelpers,
+  type RuleLogger,
+} from './apply';
 export { buildAttributes, type FileAttributes } from './attributes';
 export { type CompiledRule, compileRules } from './compile';


### PR DESCRIPTION
Adds config support for custom JsonMap lib functions.

- New config field: mapHelpers.paths (array of JS module paths, resolved relative to config dir)
- Modules may default-export an object of functions or export named functions
- Functions are merged into the JsonMap lib (override built-ins on key conflict)
- Reloads on config change (same as templateHelpers)

STAN: all scripts pass (typecheck/lint/test/diagrams/docs/build/knip).