### PR TITLE
fix: use pathToFileURL for dynamic imports on Windows

### DIFF
--- a/src/rules/apply.ts
+++ b/src/rules/apply.ts
@@ -5,6 +5,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   type Json,
@@ -126,7 +127,10 @@ export async function loadCustomMapHelpers(
   const merged: Record<string, (...args: unknown[]) => unknown> = {};
   for (const p of paths) {
     const resolved = resolve(configDir, p);
-    const mod = (await import(resolved)) as Record<string, unknown>;
+    const mod = (await import(pathToFileURL(resolved).href)) as Record<
+      string,
+      unknown
+    >;
     const fns =
       typeof mod.default === 'object' && mod.default !== null
         ? (mod.default as Record<string, unknown>)

--- a/src/templates/engine.ts
+++ b/src/templates/engine.ts
@@ -5,6 +5,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import Handlebars from 'handlebars';
 
@@ -83,7 +84,7 @@ export async function loadCustomHelpers(
 ): Promise<void> {
   for (const p of paths) {
     const resolved = resolve(configDir, p);
-    const mod = (await import(resolved)) as {
+    const mod = (await import(pathToFileURL(resolved).href)) as {
       default?: (h: typeof Handlebars) => void;
     };
     if (typeof mod.default === 'function') {


### PR DESCRIPTION
Bare Windows paths (e.g. \J:\\...\) fail with \ERR_UNSUPPORTED_ESM_URL_SCHEME\ when passed to dynamic \import()\. Wraps with \pathToFileURL().href\ in both \loadCustomMapHelpers\ and \loadCustomHelpers\.

Closes #30

STAN: all scripts pass.