### PR TITLE
chore: fix monorepo release-it tags, plugin id, and version sync

### DIFF
--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "jeeves-watcher",
+  "id": "jeeves-watcher-openclaw",
   "name": "Jeeves Watcher",
   "description": "Semantic search and metadata enrichment via a jeeves-watcher instance.",
   "version": "0.5.0",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -77,12 +77,16 @@
     "git": {
       "changelog": "npx auto-changelog --unreleased-only --stdout --template https://raw.githubusercontent.com/release-it/release-it/main/templates/changelog-compact.hbs",
       "commitMessage": "chore: release @karmaniverous/jeeves-watcher-openclaw v${version}",
+      "tagName": "openclaw/${version}",
       "requireBranch": "main"
     },
     "github": {
       "release": true
     },
     "hooks": {
+      "after:bump": [
+        "node -e \"const f='openclaw.plugin.json';const j=JSON.parse(require('fs').readFileSync(f,'utf8'));j.version='${version}';require('fs').writeFileSync(f,JSON.stringify(j,null,2)+'\\n')\""
+      ],
       "after:init": [
         "npm run lint",
         "npm run typecheck",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -133,6 +133,7 @@
     "git": {
       "changelog": "npx auto-changelog --unreleased-only --stdout --template https://raw.githubusercontent.com/release-it/release-it/main/templates/changelog-compact.hbs",
       "commitMessage": "chore: release @karmaniverous/jeeves-watcher v${version}",
+      "tagName": "service/${version}",
       "requireBranch": "main"
     },
     "github": {


### PR DESCRIPTION
- Fix release-it tagName for monorepo: service/\\\ and openclaw/\\\
- Fix openclaw.plugin.json id: jeeves-watcher -> jeeves-watcher-openclaw
- Add after:bump hook to sync openclaw.plugin.json version during release