### PR TITLE
feat: add filesystem date metadata and line offset fields to point payloads

### DIFF
--- a/packages/service/src/processor/index.ts
+++ b/packages/service/src/processor/index.ts
@@ -4,6 +4,7 @@
  * Core document processing pipeline. Handles extracting text, computing embeddings, syncing with vector store.
  */
 
+import { stat } from 'node:fs/promises';
 import { extname } from 'node:path';
 
 import type pino from 'pino';
@@ -131,7 +132,14 @@ export class DocumentProcessor implements DocumentProcessorInterface {
         this.logger.debug({ filePath }, 'Content unchanged, skipping');
         return;
       }
-      // 3. Embed→chunk→upsert pipeline
+      // 3. Filesystem date metadata
+      const fstat = await stat(filePath);
+      const fileDates = {
+        createdAt: Math.floor(fstat.birthtimeMs / 1000),
+        modifiedAt: Math.floor(fstat.mtimeMs / 1000),
+      };
+
+      // 4. Embed→chunk→upsert pipeline
       const chunkSize = this.config.chunkSize ?? 1000;
       const chunkOverlap = this.config.chunkOverlap ?? 200;
       const splitter = createSplitter(ext, chunkSize, chunkOverlap);
@@ -153,6 +161,7 @@ export class DocumentProcessor implements DocumentProcessorInterface {
         filePath,
         metadataWithRules,
         existingPayload,
+        fileDates,
       );
 
       // 4. Track success: clear issues, update values

--- a/packages/service/src/processor/lineOffsets.test.ts
+++ b/packages/service/src/processor/lineOffsets.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @module processor/lineOffsets.test
+ * Tests for line offset computation.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { computeLineOffsets } from './lineOffsets';
+
+describe('computeLineOffsets', () => {
+  it('should compute offsets for single-line chunks', () => {
+    const text = 'line 1\nline 2\nline 3';
+    const chunks = ['line 1', 'line 2', 'line 3'];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([
+      { lineStart: 1, lineEnd: 1 },
+      { lineStart: 2, lineEnd: 2 },
+      { lineStart: 3, lineEnd: 3 },
+    ]);
+  });
+
+  it('should compute offsets for multi-line chunks', () => {
+    const text = 'line 1\nline 2\nline 3\nline 4';
+    const chunks = ['line 1\nline 2', 'line 3\nline 4'];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([
+      { lineStart: 1, lineEnd: 2 },
+      { lineStart: 3, lineEnd: 4 },
+    ]);
+  });
+
+  it('should handle overlapping chunks', () => {
+    const text = 'line 1\nline 2\nline 3';
+    const chunks = ['line 1\nline 2', 'line 2\nline 3'];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([
+      { lineStart: 1, lineEnd: 2 },
+      { lineStart: 2, lineEnd: 3 },
+    ]);
+  });
+
+  it('should handle chunks not found in source', () => {
+    const text = 'line 1\nline 2';
+    const chunks = ['line 1', 'missing chunk'];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([
+      { lineStart: 1, lineEnd: 1 },
+      { lineStart: 0, lineEnd: 0 },
+    ]);
+  });
+
+  it('should handle empty chunks array', () => {
+    const text = 'line 1\nline 2';
+    const chunks: string[] = [];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty text', () => {
+    const text = '';
+    const chunks = [''];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([{ lineStart: 1, lineEnd: 1 }]);
+  });
+
+  it('should handle chunks with trailing newlines', () => {
+    const text = 'line 1\n\nline 2\n';
+    const chunks = ['line 1\n', 'line 2\n'];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([
+      { lineStart: 1, lineEnd: 2 },
+      { lineStart: 3, lineEnd: 4 },
+    ]);
+  });
+
+  it('should compute line end correctly for chunks with multiple newlines', () => {
+    const text = 'a\nb\nc\nd';
+    const chunks = ['a\nb\nc'];
+    const result = computeLineOffsets(text, chunks);
+
+    expect(result).toEqual([{ lineStart: 1, lineEnd: 3 }]);
+  });
+});

--- a/packages/service/src/processor/lineOffsets.ts
+++ b/packages/service/src/processor/lineOffsets.ts
@@ -1,0 +1,49 @@
+/**
+ * @module processor/lineOffsets
+ * Compute line offsets for text chunks within source text.
+ */
+
+/**
+ * Line offset information for a chunk.
+ */
+export interface LineOffset {
+  /** 1-indexed line number where the chunk begins. */
+  lineStart: number;
+  /** 1-indexed line number where the chunk ends. */
+  lineEnd: number;
+}
+
+/**
+ * Compute line offsets for each chunk within the source text.
+ *
+ * Handles overlapping chunks by searching from the previous chunk's start position.
+ *
+ * @param text - The source text.
+ * @param chunks - The array of text chunks.
+ * @returns Array of line offset information for each chunk.
+ */
+export function computeLineOffsets(
+  text: string,
+  chunks: string[],
+): LineOffset[] {
+  const offsets: LineOffset[] = [];
+  let searchFrom = 0;
+
+  for (const chunk of chunks) {
+    const pos = text.indexOf(chunk, searchFrom);
+    if (pos === -1) {
+      // Fallback: can't find chunk in source (shouldn't happen, but be safe)
+      offsets.push({ lineStart: 0, lineEnd: 0 });
+      continue;
+    }
+
+    const lineStart = text.slice(0, pos).split('\n').length;
+    const linesInChunk = chunk.split('\n').length - 1;
+    const lineEnd = lineStart + linesInChunk;
+
+    offsets.push({ lineStart, lineEnd });
+    searchFrom = pos; // Next chunk starts searching from here (handles overlap)
+  }
+
+  return offsets;
+}

--- a/packages/service/src/processor/payloadFields.ts
+++ b/packages/service/src/processor/payloadFields.ts
@@ -17,3 +17,15 @@ export const FIELD_CONTENT_HASH = 'content_hash';
 
 /** Qdrant payload field: the chunk text content. */
 export const FIELD_CHUNK_TEXT = 'chunk_text';
+
+/** Qdrant payload field: unix timestamp (seconds) when the file was created. */
+export const FIELD_CREATED_AT = 'created_at';
+
+/** Qdrant payload field: unix timestamp (seconds) when the file was last modified. */
+export const FIELD_MODIFIED_AT = 'modified_at';
+
+/** Qdrant payload field: 1-indexed line number where the chunk begins. */
+export const FIELD_LINE_START = 'line_start';
+
+/** Qdrant payload field: 1-indexed line number where the chunk ends. */
+export const FIELD_LINE_END = 'line_end';

--- a/packages/service/src/processor/processingPipeline.ts
+++ b/packages/service/src/processor/processingPipeline.ts
@@ -11,11 +11,16 @@ import { pointId } from '../pointId';
 import { normalizeSlashes } from '../util/normalizeSlashes';
 import type { VectorStore } from '../vectorStore';
 import { chunkIds, getChunkCount } from './chunkIds';
+import { computeLineOffsets } from './lineOffsets';
 import {
   FIELD_CHUNK_INDEX,
   FIELD_CHUNK_TEXT,
   FIELD_CONTENT_HASH,
+  FIELD_CREATED_AT,
   FIELD_FILE_PATH,
+  FIELD_LINE_END,
+  FIELD_LINE_START,
+  FIELD_MODIFIED_AT,
   FIELD_TOTAL_CHUNKS,
 } from './payloadFields';
 import type { Splitter } from './splitter';
@@ -38,6 +43,7 @@ export interface PipelineDeps {
  * @param filePath - The file path (used for point IDs).
  * @param metadata - Metadata to attach to each chunk point.
  * @param existingPayload - Existing payload from the vector store (for orphan cleanup), or null.
+ * @param fileDates - Filesystem date metadata (unix seconds).
  */
 export async function embedAndUpsert(
   deps: PipelineDeps,
@@ -45,6 +51,7 @@ export async function embedAndUpsert(
   filePath: string,
   metadata: Record<string, unknown>,
   existingPayload: Record<string, unknown> | null,
+  fileDates?: { createdAt: number; modifiedAt: number },
 ): Promise<void> {
   const { embeddingProvider, vectorStore, splitter, logger } = deps;
 
@@ -57,6 +64,9 @@ export async function embedAndUpsert(
   // Embed all chunks
   const vectors = await embeddingProvider.embed(chunks);
 
+  // Compute line offsets for each chunk
+  const lineOffsets = computeLineOffsets(text, chunks);
+
   // Upsert all chunk points
   const points = chunks.map((chunk, i) => ({
     id: pointId(filePath, i),
@@ -68,6 +78,14 @@ export async function embedAndUpsert(
       [FIELD_TOTAL_CHUNKS]: chunks.length,
       [FIELD_CONTENT_HASH]: hash,
       [FIELD_CHUNK_TEXT]: chunk,
+      [FIELD_LINE_START]: lineOffsets[i].lineStart,
+      [FIELD_LINE_END]: lineOffsets[i].lineEnd,
+      ...(fileDates
+        ? {
+            [FIELD_CREATED_AT]: fileDates.createdAt,
+            [FIELD_MODIFIED_AT]: fileDates.modifiedAt,
+          }
+        : {}),
     },
   }));
   await vectorStore.upsert(points);

--- a/packages/service/src/processor/processor.test.ts
+++ b/packages/service/src/processor/processor.test.ts
@@ -19,6 +19,14 @@ vi.mock('../metadata', () => ({
   deleteMetadata: vi.fn(),
 }));
 
+// Mock fs/promises stat for filesystem date metadata
+vi.mock('node:fs/promises', () => ({
+  stat: vi.fn().mockResolvedValue({
+    birthtimeMs: 1700000000000,
+    mtimeMs: 1700100000000,
+  }),
+}));
+
 import { deleteMetadata, readMetadata, writeMetadata } from '../metadata';
 import { buildMergedMetadata } from './buildMetadata';
 
@@ -173,6 +181,39 @@ describe('DocumentProcessor', () => {
         'rule1',
         expect.objectContaining({ domain: 'test' }),
       );
+    });
+
+    it('includes filesystem dates and line offsets in upserted payload', async () => {
+      const { vectorStore, embeddingProvider, config, logger } = createMocks();
+      mockedBuildMergedMetadata.mockResolvedValue(defaultMergedMetadata());
+      vectorStore.getPayload.mockResolvedValue(null);
+
+      const processor = new DocumentProcessor({
+        config,
+        embeddingProvider,
+        vectorStore: vectorStore as unknown as VectorStoreClient,
+        compiledRules: [],
+        logger,
+      });
+      await processor.processFile('/test.txt');
+
+      expect(vectorStore.upsert).toHaveBeenCalledOnce();
+      const points = vectorStore.upsert.mock.calls[0][0] as Array<{
+        payload: Record<string, unknown>;
+      }>;
+      expect(points.length).toBeGreaterThan(0);
+      const payload = points[0].payload;
+
+      // Filesystem dates (from mocked stat)
+      expect(payload).toHaveProperty('created_at', 1700000000);
+      expect(payload).toHaveProperty('modified_at', 1700100000);
+
+      // Line offsets
+      expect(payload).toHaveProperty('line_start');
+      expect(payload).toHaveProperty('line_end');
+      expect(typeof payload['line_start']).toBe('number');
+      expect(typeof payload['line_end']).toBe('number');
+      expect(payload['line_start']).toBeGreaterThanOrEqual(1);
     });
 
     it('does not record a v2 issue on generic error', async () => {


### PR DESCRIPTION
Adds four new system payload fields to every Qdrant point:

- `created_at` — unix timestamp (seconds) from `fs.stat().birthtime`
- `modified_at` — unix timestamp (seconds) from `fs.stat().mtime`
- `line_start` — 1-indexed line number where this chunk begins in the source file
- `line_end` — 1-indexed line number where this chunk ends in the source file

These fields are the foundation for:
- `memory_search` line ranges (`from`/`to` mapping in v0.6.0)
- Date-range filtering on indexed content
- Precise file-range reads via `memory_get(path, from, lines)`

### Changes
- `payloadFields.ts`: 4 new field constants
- `processingPipeline.ts`: Accept `fileDates` param, compute line offsets via `computeLineOffsets()`, add all 4 fields to point payload
- `index.ts`: Call `fs.stat()` in `processFile()`, pass dates to pipeline
- `lineOffsets.ts`: Pure function for chunk→line mapping (new module)
- `lineOffsets.test.ts`: 8 test cases (single-line, multi-line, overlapping, edge cases)
- `processor.test.ts`: New test verifying all 4 fields in upserted payload