### PR TITLE
feat(service): add filesystem date metadata and line offsets

### DIFF
--- a/packages/service/src/processor/index.ts
+++ b/packages/service/src/processor/index.ts
@@ -4,6 +4,7 @@
  * Core document processing pipeline. Handles extracting text, computing embeddings, syncing with vector store.
  */
 
+import { stat } from 'node:fs/promises';
 import { extname } from 'node:path';
 
 import type pino from 'pino';
@@ -142,6 +143,13 @@ export class DocumentProcessor implements DocumentProcessorInterface {
         matched_rules: matchedRules,
       };
 
+      // Get file dates from filesystem
+      const stats = await stat(filePath);
+      const fileDates = {
+        createdAt: Math.floor(stats.birthtimeMs / 1000),
+        modifiedAt: Math.floor(stats.mtimeMs / 1000),
+      };
+
       await embedAndUpsert(
         {
           embeddingProvider: this.embeddingProvider,
@@ -153,6 +161,7 @@ export class DocumentProcessor implements DocumentProcessorInterface {
         filePath,
         metadataWithRules,
         existingPayload,
+        fileDates,
       );
 
       // 4. Track success: clear issues, update values

--- a/packages/service/src/processor/lineOffsets.test.ts
+++ b/packages/service/src/processor/lineOffsets.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeLineOffsets } from './lineOffsets';
+
+describe('computeLineOffsets', () => {
+  it('returns empty array for empty text', () => {
+    expect(computeLineOffsets('', ['chunk'])).toEqual([]);
+  });
+
+  it('returns empty array for empty chunks', () => {
+    expect(computeLineOffsets('hello\nworld', [])).toEqual([]);
+  });
+
+  it('single chunk covering entire text', () => {
+    const text = 'line1\nline2\nline3';
+    expect(computeLineOffsets(text, [text])).toEqual([
+      { lineStart: 1, lineEnd: 3 },
+    ]);
+  });
+
+  it('single-line text', () => {
+    const text = 'no newlines here';
+    expect(computeLineOffsets(text, [text])).toEqual([
+      { lineStart: 1, lineEnd: 1 },
+    ]);
+  });
+
+  it('multiple chunks with no overlap', () => {
+    const text = 'aaa\nbbb\nccc\nddd';
+    const chunks = ['aaa\nbbb', 'ccc\nddd'];
+    expect(computeLineOffsets(text, chunks)).toEqual([
+      { lineStart: 1, lineEnd: 2 },
+      { lineStart: 3, lineEnd: 4 },
+    ]);
+  });
+
+  it('multiple chunks with overlap', () => {
+    // Simulate overlap: chunk2 starts partway through chunk1's range
+    const text = 'line1\nline2\nline3\nline4\nline5';
+    const chunk1 = 'line1\nline2\nline3';
+    const chunk2 = 'line2\nline3\nline4';
+    const chunk3 = 'line3\nline4\nline5';
+    expect(computeLineOffsets(text, [chunk1, chunk2, chunk3])).toEqual([
+      { lineStart: 1, lineEnd: 3 },
+      { lineStart: 2, lineEnd: 4 },
+      { lineStart: 3, lineEnd: 5 },
+    ]);
+  });
+
+  it('chunk that starts mid-line', () => {
+    const text = 'hello world\nsecond line';
+    const chunk = 'world\nsecond line';
+    expect(computeLineOffsets(text, [chunk])).toEqual([
+      { lineStart: 1, lineEnd: 2 },
+    ]);
+  });
+
+  it('text with varying line lengths', () => {
+    const text = 'a\nbb\nccc\ndddd\neeeee';
+    const chunks = ['a\nbb\nccc', 'dddd\neeeee'];
+    expect(computeLineOffsets(text, chunks)).toEqual([
+      { lineStart: 1, lineEnd: 3 },
+      { lineStart: 4, lineEnd: 5 },
+    ]);
+  });
+
+  it('last chunk ending at EOF without trailing newline', () => {
+    const text = 'first\nsecond\nthird';
+    const chunks = ['first\nsecond', 'third'];
+    expect(computeLineOffsets(text, chunks)).toEqual([
+      { lineStart: 1, lineEnd: 2 },
+      { lineStart: 3, lineEnd: 3 },
+    ]);
+  });
+
+  it('handles chunk not found in text gracefully', () => {
+    const text = 'hello\nworld';
+    const chunks = ['hello', 'NOTFOUND', 'world'];
+    const result = computeLineOffsets(text, chunks);
+    expect(result).toHaveLength(3);
+    // First chunk found normally
+    expect(result[0]).toEqual({ lineStart: 1, lineEnd: 1 });
+    // Not-found chunk gets fallback
+    expect(result[1]).toBeDefined();
+    // Third chunk still found
+    expect(result[2]).toEqual({ lineStart: 2, lineEnd: 2 });
+  });
+});

--- a/packages/service/src/processor/lineOffsets.ts
+++ b/packages/service/src/processor/lineOffsets.ts
@@ -1,0 +1,65 @@
+/**
+ * @module processor/lineOffsets
+ * Compute 1-indexed line ranges for chunks within source text.
+ */
+
+/**
+ * Compute 1-indexed line start and end for each chunk within the source text.
+ *
+ * @param fullText - The complete source text.
+ * @param chunks - Array of chunk strings extracted from fullText.
+ * @returns Array of `{ lineStart, lineEnd }` for each chunk.
+ */
+export function computeLineOffsets(
+  fullText: string,
+  chunks: string[],
+): Array<{ lineStart: number; lineEnd: number }> {
+  if (!fullText || chunks.length === 0) return [];
+
+  // Build cumulative line-start character offsets
+  const lineStarts = [0];
+  for (let i = 0; i < fullText.length; i++) {
+    if (fullText[i] === '\n') {
+      lineStarts.push(i + 1);
+    }
+  }
+
+  /** Map a character offset to a 1-indexed line number. */
+  function offsetToLine(offset: number): number {
+    // Binary search for the largest lineStart <= offset
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStarts[mid] <= offset) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo + 1; // 1-indexed
+  }
+
+  const results: Array<{ lineStart: number; lineEnd: number }> = [];
+  let searchFrom = 0;
+
+  for (const chunk of chunks) {
+    const pos = fullText.indexOf(chunk, searchFrom);
+    if (pos === -1) {
+      // Chunk not found — fall back to searchFrom position
+      results.push({
+        lineStart: offsetToLine(searchFrom),
+        lineEnd: offsetToLine(searchFrom),
+      });
+      continue;
+    }
+
+    const lineStart = offsetToLine(pos);
+    const endPos = pos + chunk.length - 1;
+    const lineEnd =
+      chunk.length === 0 ? lineStart : offsetToLine(Math.max(pos, endPos));
+
+    results.push({ lineStart, lineEnd });
+    // Advance searchFrom past the START of this chunk (not end) to handle overlap
+    searchFrom = pos + 1;
+  }
+
+  return results;
+}

--- a/packages/service/src/processor/payloadFields.ts
+++ b/packages/service/src/processor/payloadFields.ts
@@ -17,3 +17,15 @@ export const FIELD_CONTENT_HASH = 'content_hash';
 
 /** Qdrant payload field: the chunk text content. */
 export const FIELD_CHUNK_TEXT = 'chunk_text';
+
+/** Qdrant payload field: file creation timestamp (unix seconds from fs.stat birthtime). */
+export const FIELD_CREATED_AT = 'created_at';
+
+/** Qdrant payload field: file modification timestamp (unix seconds from fs.stat mtime). */
+export const FIELD_MODIFIED_AT = 'modified_at';
+
+/** Qdrant payload field: 1-indexed line number where this chunk starts in the source file. */
+export const FIELD_LINE_START = 'line_start';
+
+/** Qdrant payload field: 1-indexed line number where this chunk ends in the source file. */
+export const FIELD_LINE_END = 'line_end';

--- a/packages/service/src/processor/processingPipeline.ts
+++ b/packages/service/src/processor/processingPipeline.ts
@@ -11,11 +11,16 @@ import { pointId } from '../pointId';
 import { normalizeSlashes } from '../util/normalizeSlashes';
 import type { VectorStore } from '../vectorStore';
 import { chunkIds, getChunkCount } from './chunkIds';
+import { computeLineOffsets } from './lineOffsets';
 import {
   FIELD_CHUNK_INDEX,
   FIELD_CHUNK_TEXT,
   FIELD_CONTENT_HASH,
+  FIELD_CREATED_AT,
   FIELD_FILE_PATH,
+  FIELD_LINE_END,
+  FIELD_LINE_START,
+  FIELD_MODIFIED_AT,
   FIELD_TOTAL_CHUNKS,
 } from './payloadFields';
 import type { Splitter } from './splitter';
@@ -38,6 +43,7 @@ export interface PipelineDeps {
  * @param filePath - The file path (used for point IDs).
  * @param metadata - Metadata to attach to each chunk point.
  * @param existingPayload - Existing payload from the vector store (for orphan cleanup), or null.
+ * @param fileDates - File creation and modification timestamps (unix seconds).
  */
 export async function embedAndUpsert(
   deps: PipelineDeps,
@@ -45,6 +51,7 @@ export async function embedAndUpsert(
   filePath: string,
   metadata: Record<string, unknown>,
   existingPayload: Record<string, unknown> | null,
+  fileDates: { createdAt: number; modifiedAt: number },
 ): Promise<void> {
   const { embeddingProvider, vectorStore, splitter, logger } = deps;
 
@@ -53,6 +60,9 @@ export async function embedAndUpsert(
 
   // Chunk text
   const chunks = await splitter.splitText(text);
+
+  // Compute line offsets
+  const offsets = computeLineOffsets(text, chunks);
 
   // Embed all chunks
   const vectors = await embeddingProvider.embed(chunks);
@@ -68,6 +78,10 @@ export async function embedAndUpsert(
       [FIELD_TOTAL_CHUNKS]: chunks.length,
       [FIELD_CONTENT_HASH]: hash,
       [FIELD_CHUNK_TEXT]: chunk,
+      [FIELD_CREATED_AT]: fileDates.createdAt,
+      [FIELD_MODIFIED_AT]: fileDates.modifiedAt,
+      [FIELD_LINE_START]: offsets[i]?.lineStart ?? 1,
+      [FIELD_LINE_END]: offsets[i]?.lineEnd ?? 1,
     },
   }));
   await vectorStore.upsert(points);

--- a/packages/service/src/processor/processor.test.ts
+++ b/packages/service/src/processor/processor.test.ts
@@ -19,6 +19,15 @@ vi.mock('../metadata', () => ({
   deleteMetadata: vi.fn(),
 }));
 
+// Mock node:fs/promises stat() to return predictable values
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  stat: vi.fn().mockResolvedValue({
+    birthtimeMs: 1700000000000,
+    mtimeMs: 1700100000000,
+  }),
+}));
+
 import { deleteMetadata, readMetadata, writeMetadata } from '../metadata';
 import { buildMergedMetadata } from './buildMetadata';
 

--- a/packages/service/src/processor/processorFileDates.test.ts
+++ b/packages/service/src/processor/processorFileDates.test.ts
@@ -1,0 +1,100 @@
+import pino from 'pino';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import type { EmbeddingProvider } from '../embedding';
+import type { VectorStoreClient } from '../vectorStore';
+import { DocumentProcessor, type ProcessorConfig } from './index';
+
+// Mock buildMergedMetadata so we don't touch the filesystem
+vi.mock('./buildMetadata', () => ({
+  buildMergedMetadata: vi.fn(),
+}));
+
+// Mock metadata I/O
+vi.mock('../metadata', () => ({
+  readMetadata: vi.fn(),
+  writeMetadata: vi.fn(),
+  deleteMetadata: vi.fn(),
+}));
+
+// Mock node:fs/promises stat() to return predictable values
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  stat: vi.fn().mockResolvedValue({
+    birthtimeMs: 1700000000000,
+    mtimeMs: 1700100000000,
+  }),
+}));
+
+import { buildMergedMetadata } from './buildMetadata';
+
+const mockedBuildMergedMetadata = buildMergedMetadata as Mock;
+
+interface MockVectorStore {
+  getPayload: Mock;
+  upsert: Mock;
+  delete: Mock;
+  setPayload: Mock;
+}
+
+describe('DocumentProcessor file date & line offset fields', () => {
+  let vectorStore: MockVectorStore;
+  let embeddingProvider: EmbeddingProvider;
+  let processor: DocumentProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vectorStore = {
+      getPayload: vi.fn().mockResolvedValue(null),
+      upsert: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      setPayload: vi.fn().mockResolvedValue(undefined),
+    };
+
+    embeddingProvider = {
+      dimensions: 3,
+      embed: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]),
+    };
+
+    const config: ProcessorConfig = {
+      metadataDir: '/tmp/meta',
+      chunkSize: 1000,
+      chunkOverlap: 200,
+    };
+
+    processor = new DocumentProcessor({
+      config,
+      embeddingProvider,
+      vectorStore: vectorStore as unknown as VectorStoreClient,
+      compiledRules: [],
+      logger: pino({ level: 'silent' }),
+    });
+  });
+
+  it('includes created_at, modified_at, line_start, line_end in upserted points', async () => {
+    mockedBuildMergedMetadata.mockResolvedValue({
+      metadata: { domain: 'test' },
+      extracted: { text: 'line1\nline2\nline3', frontmatter: null, json: null },
+      renderedContent: null,
+      matchedRules: ['rule1'],
+      inferred: { domain: 'test' },
+      enrichment: null,
+      attributes: {},
+    });
+
+    await processor.processFile('/test.txt');
+
+    expect(vectorStore.upsert).toHaveBeenCalledOnce();
+    const points = vectorStore.upsert.mock.calls[0][0] as Array<{
+      payload: Record<string, unknown>;
+    }>;
+    expect(points.length).toBeGreaterThan(0);
+
+    const payload = points[0].payload;
+    expect(payload['created_at']).toBe(1700000000);
+    expect(payload['modified_at']).toBe(1700100000);
+    expect(payload['line_start']).toBe(1);
+    expect(payload['line_end']).toBe(3);
+  });
+});


### PR DESCRIPTION
Adds 4 new payload fields to the processing pipeline: `created_at`, `modified_at` (unix seconds from fs stat), `line_start`, `line_end` (1-indexed line numbers per chunk).

- New `payloadFields` constants for the 4 fields
- `computeLineOffsets()` pure function with 8 unit tests
- `processingPipeline` accepts `fileDates` parameter
- `processor.ts` calls `stat()` and passes dates downstream
- Unit tests for file date propagation

Closes #24
