### PR TITLE
feat(service): hybrid search with BM25 text index and RRF fusion

### DIFF
--- a/commitmsg.txt
+++ b/commitmsg.txt
@@ -1,8 +1,10 @@
-feat: Handlebars set expressions + date normalization helpers
+feat(service): add hybrid search with BM25 text index and RRF fusion
 
-- Add toUnix and toUnixMs Handlebars helpers for date normalization
-- Replace regex-based ${...} template vars with Handlebars compilation
-  when hbs instance is available (backward compat preserved)
-- Expose hbs on TemplateEngine (private -> readonly)
-- Thread hbs through resolveAndCoerce -> resolveTemplateVars pipeline
-- Update tests for Handlebars syntax + backward compat + new helpers
+- Add search.hybrid config section (enabled, textWeight)
+- Add ensureTextIndex() for BM25 full-text index on chunk_text
+- Implement hybridSearch() using Qdrant Query API with prefetch + RRF
+- Search handler switches between vector-only and hybrid based on config
+- Text index created at startup when hybrid is enabled
+- 2 new search handler tests (hybrid on/off paths)
+
+Closes #35

--- a/packages/service/src/api/handlers/search.test.ts
+++ b/packages/service/src/api/handlers/search.test.ts
@@ -10,12 +10,18 @@ describe('createSearchHandler', () => {
       { id: 'p1', score: 0.95, payload: { path: '/a.txt' } },
     ]);
 
+  const hybridSearchMock = vi
+    .fn()
+    .mockResolvedValue([
+      { id: 'p2', score: 0.88, payload: { path: '/b.txt' } },
+    ]);
+
   const mockDeps = {
     embeddingProvider: {
       embed: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]),
       dimensions: 3,
     },
-    vectorStore: { search: searchMock },
+    vectorStore: { search: searchMock, hybridSearch: hybridSearchMock },
     logger: { error: vi.fn() },
   } as unknown as SearchRouteDeps;
 
@@ -37,6 +43,52 @@ describe('createSearchHandler', () => {
 
   it('defaults limit to 10 and filter to undefined', async () => {
     const handler = createSearchHandler(mockDeps);
+    const request = { body: { query: 'test' } } as never;
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as never;
+
+    await handler(request, reply);
+
+    expect(searchMock).toHaveBeenCalledWith(
+      [0.1, 0.2, 0.3],
+      10,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('uses hybridSearch when hybrid config is enabled', async () => {
+    const hybridDeps = {
+      ...mockDeps,
+      hybridConfig: { enabled: true, textWeight: 0.3 },
+    } as unknown as SearchRouteDeps;
+
+    const handler = createSearchHandler(hybridDeps);
+    const filter = { must: [{ key: 'domain', match: { value: 'email' } }] };
+    const request = {
+      body: { query: 'test query', limit: 5, filter },
+    } as never;
+    const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as never;
+
+    await handler(request, reply);
+
+    expect(hybridSearchMock).toHaveBeenCalledWith(
+      [0.1, 0.2, 0.3],
+      'test query',
+      5,
+      0.3,
+      filter,
+    );
+    expect(searchMock).not.toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to vector search when hybrid is disabled', async () => {
+    searchMock.mockClear();
+    const hybridDeps = {
+      ...mockDeps,
+      hybridConfig: { enabled: false, textWeight: 0.3 },
+    } as unknown as SearchRouteDeps;
+
+    const handler = createSearchHandler(hybridDeps);
     const request = { body: { query: 'test' } } as never;
     const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as never;
 

--- a/packages/service/src/api/handlers/search.ts
+++ b/packages/service/src/api/handlers/search.ts
@@ -10,10 +10,17 @@ import type { EmbeddingProvider } from '../../embedding';
 import type { VectorStore } from '../../vectorStore';
 import { wrapHandler } from './wrapHandler';
 
+/** Hybrid search configuration passed to the search handler. */
+export interface HybridSearchConfig {
+  enabled: boolean;
+  textWeight: number;
+}
+
 export interface SearchRouteDeps {
   embeddingProvider: EmbeddingProvider;
   vectorStore: VectorStore;
   logger: pino.Logger;
+  hybridConfig?: HybridSearchConfig;
 }
 
 type SearchRequest = FastifyRequest<{
@@ -35,13 +42,18 @@ export function createSearchHandler(deps: SearchRouteDeps) {
     async (request: SearchRequest) => {
       const { query, limit = 10, offset, filter } = request.body;
       const vectors = await deps.embeddingProvider.embed([query]);
-      const results = await deps.vectorStore.search(
-        vectors[0],
-        limit,
-        filter,
-        offset,
-      );
-      return results;
+
+      if (deps.hybridConfig?.enabled) {
+        return deps.vectorStore.hybridSearch(
+          vectors[0],
+          query,
+          limit,
+          deps.hybridConfig.textWeight,
+          filter,
+        );
+      }
+
+      return deps.vectorStore.search(vectors[0], limit, filter, offset);
     },
     deps.logger,
     'Search',

--- a/packages/service/src/api/index.ts
+++ b/packages/service/src/api/index.ts
@@ -109,9 +109,21 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
 
   app.post('/metadata', createMetadataHandler({ processor, config, logger }));
 
+  const hybridConfig = config.search?.hybrid
+    ? {
+        enabled: config.search.hybrid.enabled,
+        textWeight: config.search.hybrid.textWeight,
+      }
+    : undefined;
+
   app.post(
     '/search',
-    createSearchHandler({ embeddingProvider, vectorStore, logger }),
+    createSearchHandler({
+      embeddingProvider,
+      vectorStore,
+      logger,
+      hybridConfig,
+    }),
   );
 
   app.post(

--- a/packages/service/src/app/index.ts
+++ b/packages/service/src/app/index.ts
@@ -90,6 +90,10 @@ export class JeevesWatcher {
       logger,
     );
 
+    if (this.config.search?.hybrid?.enabled) {
+      await vectorStore.ensureTextIndex('chunk_text');
+    }
+
     const compiledRules = this.factories.compileRules(
       this.config.inferenceRules ?? [],
     );

--- a/packages/service/src/config/schemas/root.ts
+++ b/packages/service/src/config/schemas/root.ts
@@ -152,7 +152,7 @@ export const jeevesWatcherConfigSchema = z.object({
     .record(z.string(), z.unknown())
     .optional()
     .describe('Named Qdrant filter patterns for skill-activated behaviors.'),
-  /** Search configuration including score thresholds. */
+  /** Search configuration including score thresholds and hybrid search. */
   search: z
     .object({
       /** Score thresholds for categorizing search result quality. */
@@ -166,9 +166,20 @@ export const jeevesWatcherConfigSchema = z.object({
           noise: z.number().min(-1).max(1),
         })
         .optional(),
+      /** Hybrid search configuration combining vector and full-text search. */
+      hybrid: z
+        .object({
+          /** Enable hybrid search with RRF fusion. Default: false. */
+          enabled: z.boolean().default(false),
+          /** Weight for text (BM25) results in RRF fusion. Default: 0.3. */
+          textWeight: z.number().min(0).max(1).default(0.3),
+        })
+        .optional(),
     })
     .optional()
-    .describe('Search configuration including score thresholds.'),
+    .describe(
+      'Search configuration including score thresholds and hybrid search.',
+    ),
   /** Logging configuration. */
   logging: loggingConfigSchema.optional().describe('Logging configuration.'),
   /** Timeout in milliseconds for graceful shutdown. */

--- a/packages/service/src/vectorStore/collectionInfo.ts
+++ b/packages/service/src/vectorStore/collectionInfo.ts
@@ -1,0 +1,75 @@
+/**
+ * @module vectorStore/collectionInfo
+ * Collection introspection helpers for Qdrant vector store.
+ */
+
+import type { QdrantClient } from '@qdrant/js-client-rest';
+
+import { inferPayloadType } from './helpers';
+import type { CollectionInfo, PayloadFieldSchema } from './types';
+
+/**
+ * Sample points and discover payload field names and inferred types.
+ *
+ * @param client - Qdrant client instance.
+ * @param collectionName - Name of the Qdrant collection.
+ * @param target - Object to populate with discovered fields.
+ * @param sampleSize - Number of points to sample.
+ */
+export async function discoverPayloadFields(
+  client: QdrantClient,
+  collectionName: string,
+  target: Record<string, PayloadFieldSchema>,
+  sampleSize = 100,
+): Promise<void> {
+  const result = await client.scroll(collectionName, {
+    limit: sampleSize,
+    with_payload: true,
+    with_vector: false,
+  });
+
+  for (const point of result.points) {
+    const payload = point.payload as Record<string, unknown> | undefined;
+    if (!payload) continue;
+    for (const [key, value] of Object.entries(payload)) {
+      if (key in target) continue;
+      target[key] = { type: inferPayloadType(value) };
+    }
+  }
+}
+
+/**
+ * Get collection info including point count, dimensions, and payload field schema.
+ *
+ * When Qdrant has payload indexes, uses `payload_schema` directly. Otherwise
+ * samples points to discover fields and infer types.
+ *
+ * @param client - Qdrant client instance.
+ * @param collectionName - Name of the Qdrant collection.
+ */
+export async function getCollectionInfo(
+  client: QdrantClient,
+  collectionName: string,
+): Promise<CollectionInfo> {
+  const info = await client.getCollection(collectionName);
+  const pointCount = info.points_count ?? 0;
+  const vectorsConfig = info.config.params.vectors;
+  const dimensions =
+    vectorsConfig !== undefined && 'size' in vectorsConfig
+      ? (vectorsConfig as { size: number }).size
+      : 0;
+
+  const payloadFields: Record<string, PayloadFieldSchema> = {};
+  const schemaEntries = Object.entries(info.payload_schema);
+  if (schemaEntries.length > 0) {
+    for (const [key, schema] of schemaEntries) {
+      payloadFields[key] = {
+        type: (schema as { data_type?: string }).data_type ?? 'unknown',
+      };
+    }
+  } else if (pointCount > 0) {
+    await discoverPayloadFields(client, collectionName, payloadFields);
+  }
+
+  return { pointCount, dimensions, payloadFields };
+}

--- a/packages/service/src/vectorStore/hybridSearch.ts
+++ b/packages/service/src/vectorStore/hybridSearch.ts
@@ -1,0 +1,120 @@
+/**
+ * @module vectorStore/hybridSearch
+ * Hybrid search and text index helpers for Qdrant vector store.
+ */
+
+import type { QdrantClient } from '@qdrant/js-client-rest';
+import type pino from 'pino';
+
+import type { SearchResult } from './types';
+
+/**
+ * Create a full-text payload index on the specified field.
+ * Idempotent — skips if the field already has an index.
+ *
+ * @param client - Qdrant client instance.
+ * @param collectionName - Name of the Qdrant collection.
+ * @param fieldName - The payload field to index.
+ * @param log - Logger instance.
+ */
+export async function ensureTextIndex(
+  client: QdrantClient,
+  collectionName: string,
+  fieldName: string,
+  log: pino.Logger,
+): Promise<void> {
+  try {
+    const info = await client.getCollection(collectionName);
+    const existing = info.payload_schema[fieldName];
+    if (existing) {
+      log.info({ fieldName }, 'Text index already exists, skipping creation');
+      return;
+    }
+  } catch {
+    // Collection may not exist yet; proceed to create index anyway.
+  }
+
+  try {
+    await client.createPayloadIndex(collectionName, {
+      field_name: fieldName,
+      field_schema: {
+        type: 'text',
+        tokenizer: 'word',
+        min_token_len: 2,
+        lowercase: true,
+      },
+      wait: true,
+    });
+    log.info({ fieldName }, 'Full-text payload index created');
+  } catch (error) {
+    throw new Error(
+      `Failed to create text index on "${fieldName}": ${String(error)}`,
+    );
+  }
+}
+
+/**
+ * Hybrid search combining dense vector and full-text match with RRF fusion.
+ *
+ * Uses Qdrant Query API with two prefetches:
+ * 1. Dense vector similarity search
+ * 2. Dense vector search filtered to documents matching the query text
+ *
+ * Results are fused using Reciprocal Rank Fusion (RRF) with configurable weights.
+ *
+ * @param client - Qdrant client instance.
+ * @param collectionName - Name of the Qdrant collection.
+ * @param vector - The query vector.
+ * @param queryText - The raw query text for full-text matching.
+ * @param limit - Maximum results to return.
+ * @param textWeight - Weight for text results in RRF (0–1).
+ * @param filter - Optional Qdrant filter.
+ * @returns An array of search results.
+ */
+export async function hybridSearch(
+  client: QdrantClient,
+  collectionName: string,
+  vector: number[],
+  queryText: string,
+  limit: number,
+  textWeight: number,
+  filter?: Record<string, unknown>,
+): Promise<SearchResult[]> {
+  const prefetchLimit = Math.max(limit * 3, 20);
+  const vectorWeight = 1 - textWeight;
+
+  const textFilter = {
+    must: [
+      ...(filter ? ((filter as { must?: unknown[] }).must ?? []) : []),
+      { key: 'chunk_text', match: { text: queryText } },
+    ],
+  };
+
+  const result = await client.query(collectionName, {
+    prefetch: [
+      {
+        query: vector,
+        limit: prefetchLimit,
+        ...(filter ? { filter } : {}),
+      },
+      {
+        query: vector,
+        filter: textFilter,
+        limit: prefetchLimit,
+      },
+    ],
+    query: {
+      rrf: {
+        weights: [vectorWeight, textWeight],
+      },
+    },
+    limit,
+    with_payload: true,
+  });
+
+  return result.points.map((p) => ({
+    id: String(p.id),
+    score: p.score,
+    payload: p.payload as Record<string, unknown>,
+  }));
+}

--- a/packages/service/src/vectorStore/index.ts
+++ b/packages/service/src/vectorStore/index.ts
@@ -5,10 +5,13 @@ import type { VectorStoreConfig } from '../config/types';
 import { getLogger, type MinimalLogger } from '../util/logger';
 import { normalizeError } from '../util/normalizeError';
 import { retry } from '../util/retry';
-import { inferPayloadType } from './helpers';
+import { getCollectionInfo as getCollectionInfoHelper } from './collectionInfo';
+import {
+  ensureTextIndex as ensureTextIndexHelper,
+  hybridSearch as hybridSearchHelper,
+} from './hybridSearch';
 import type {
   CollectionInfo,
-  PayloadFieldSchema,
   ScrolledPoint,
   SearchResult,
   VectorPoint,
@@ -23,7 +26,7 @@ export type {
   SearchResult,
   VectorPoint,
   VectorStore,
-};
+} from './types';
 
 /**
  * Client wrapper for Qdrant vector store operations.
@@ -35,6 +38,7 @@ export class VectorStoreClient implements VectorStore {
   private readonly collectionName: string;
   private readonly dims: number;
   private readonly log: MinimalLogger;
+  private readonly pinoLogger?: pino.Logger;
 
   /**
    * Create a new VectorStoreClient.
@@ -56,6 +60,7 @@ export class VectorStoreClient implements VectorStore {
     this.collectionName = config.collectionName;
     this.dims = dimensions;
     this.log = getLogger(logger);
+    this.pinoLogger = logger;
   }
 
   /**
@@ -202,55 +207,7 @@ export class VectorStoreClient implements VectorStore {
    * samples points to discover fields and infer types.
    */
   async getCollectionInfo(): Promise<CollectionInfo> {
-    const info = await this.client.getCollection(this.collectionName);
-    const pointCount = info.points_count ?? 0;
-    const vectorsConfig = info.config.params.vectors;
-    const dimensions =
-      vectorsConfig !== undefined && 'size' in vectorsConfig
-        ? (vectorsConfig as { size: number }).size
-        : 0;
-
-    // Try indexed payload_schema first.
-    const payloadFields: Record<string, PayloadFieldSchema> = {};
-    const schemaEntries = Object.entries(info.payload_schema);
-    if (schemaEntries.length > 0) {
-      for (const [key, schema] of schemaEntries) {
-        payloadFields[key] = {
-          type: (schema as { data_type?: string }).data_type ?? 'unknown',
-        };
-      }
-    } else if (pointCount > 0) {
-      // No indexed schema — sample points to discover fields.
-      await this.discoverPayloadFields(payloadFields);
-    }
-
-    return { pointCount, dimensions, payloadFields };
-  }
-
-  /**
-   * Sample points and discover payload field names and inferred types.
-   *
-   * @param target - Object to populate with discovered fields.
-   * @param sampleSize - Number of points to sample.
-   */
-  private async discoverPayloadFields(
-    target: Record<string, PayloadFieldSchema>,
-    sampleSize = 100,
-  ): Promise<void> {
-    const result = await this.client.scroll(this.collectionName, {
-      limit: sampleSize,
-      with_payload: true,
-      with_vector: false,
-    });
-
-    for (const point of result.points) {
-      const payload = point.payload as Record<string, unknown> | undefined;
-      if (!payload) continue;
-      for (const [key, value] of Object.entries(payload)) {
-        if (key in target) continue;
-        target[key] = { type: inferPayloadType(value) };
-      }
-    }
+    return getCollectionInfoHelper(this.client, this.collectionName);
   }
 
   /**
@@ -279,6 +236,52 @@ export class VectorStoreClient implements VectorStore {
       score: r.score,
       payload: r.payload as Record<string, unknown>,
     }));
+  }
+
+  /**
+   * Create a full-text payload index on the specified field.
+   * Idempotent — skips if the field already has a text index.
+   *
+   * @param fieldName - The payload field to index.
+   */
+  async ensureTextIndex(fieldName: string): Promise<void> {
+    if (!this.pinoLogger) {
+      throw new Error('Logger required for ensureTextIndex');
+    }
+    await ensureTextIndexHelper(
+      this.client,
+      this.collectionName,
+      fieldName,
+      this.pinoLogger,
+    );
+  }
+
+  /**
+   * Hybrid search combining dense vector and full-text match with RRF fusion.
+   *
+   * @param vector - The query vector.
+   * @param queryText - The raw query text for full-text matching.
+   * @param limit - Maximum results to return.
+   * @param textWeight - Weight for text results in RRF (0–1).
+   * @param filter - Optional Qdrant filter.
+   * @returns An array of search results.
+   */
+  async hybridSearch(
+    vector: number[],
+    queryText: string,
+    limit: number,
+    textWeight: number,
+    filter?: Record<string, unknown>,
+  ): Promise<SearchResult[]> {
+    return hybridSearchHelper(
+      this.client,
+      this.collectionName,
+      vector,
+      queryText,
+      limit,
+      textWeight,
+      filter,
+    );
   }
 
   /**

--- a/packages/service/src/vectorStore/types.ts
+++ b/packages/service/src/vectorStore/types.ts
@@ -128,4 +128,29 @@ export interface VectorStore {
     filter?: Record<string, unknown>,
     limit?: number,
   ): AsyncGenerator<ScrolledPoint>;
+
+  /**
+   * Create a full-text payload index on the specified field.
+   *
+   * @param fieldName - The payload field to index.
+   */
+  ensureTextIndex(fieldName: string): Promise<void>;
+
+  /**
+   * Hybrid search combining dense vector and full-text match with RRF fusion.
+   *
+   * @param vector - The query vector.
+   * @param queryText - The raw query text for full-text matching.
+   * @param limit - Maximum results to return.
+   * @param textWeight - Weight for text results in RRF (0–1).
+   * @param filter - Optional Qdrant filter.
+   * @returns An array of search results.
+   */
+  hybridSearch(
+    vector: number[],
+    queryText: string,
+    limit: number,
+    textWeight: number,
+    filter?: Record<string, unknown>,
+  ): Promise<SearchResult[]>;
 }


### PR DESCRIPTION
Add config-gated hybrid search combining dense vector similarity with BM25 full-text matching via Qdrant's Query API and Reciprocal Rank Fusion (RRF).

- New `search.hybrid` config section: `enabled` (default false), `textWeight` (default 0.3)
- `ensureTextIndex()` creates BM25 full-text index on `chunk_text` at startup when hybrid enabled
- `hybridSearch()` uses Qdrant Query API with two prefetch queries (dense vector + text-filtered vector) fused via RRF
- Search handler switches between vector-only and hybrid based on config
- No re-embedding needed - builds text index from existing chunk_text payload data
- 2 new unit tests for hybrid on/off search paths

Closes #35
