### PR TITLE
fix: plugin installer claims memory slot in OpenClaw config

### DIFF
--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -128,6 +128,24 @@ export function patchConfig(
     messages.push(`Removed "${PLUGIN_ID}" from plugins.entries`);
   }
 
+  // plugins.slots — claim or release the memory slot
+  if (!plugins.slots || typeof plugins.slots !== 'object') {
+    plugins.slots = {};
+  }
+  const slots = plugins.slots as Record<string, unknown>;
+  if (mode === 'add') {
+    const prev = slots.memory;
+    slots.memory = PLUGIN_ID;
+    if (prev !== PLUGIN_ID) {
+      messages.push(
+        `Set plugins.slots.memory to "${PLUGIN_ID}"${prev ? ` (was "${prev as string}")` : ''}`,
+      );
+    }
+  } else if (slots.memory === PLUGIN_ID) {
+    slots.memory = 'memory-core';
+    messages.push(`Reverted plugins.slots.memory to "memory-core"`);
+  }
+
   // tools.allow
   const tools = (config.tools ?? {}) as Record<string, unknown>;
   const toolAllow = patchAllowList(tools, 'allow', 'tools.allow', mode);


### PR DESCRIPTION
The custom install CLI (workaround for OpenClaw Windows spawn EINVAL) was adding the plugin to plugins.entries but not updating plugins.slots.memory. OpenClaw's native plugin installer handles slot assignment automatically, but our bypass skipped it. Now patchConfig sets plugins.slots.memory to the plugin ID on install, and reverts to memory-core on uninstall.