### PR TITLE
chore: bump @karmaniverous/jsonmap to 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,9 +1737,9 @@
       "link": true
     },
     "node_modules/@karmaniverous/jsonmap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jsonmap/-/jsonmap-2.1.0.tgz",
-      "integrity": "sha512-1O29tyoRkwXMms1XunBcyHcVW+ueLakMNwqqSX6euyLYifsKKFUg4IPKRhRcapJYzYrn+tT+u67O5r4tr17CIQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jsonmap/-/jsonmap-2.1.1.tgz",
+      "integrity": "sha512-8qa2kgjxNmoQo5XaH2c9Y+T6rDIflyv37GAEXHeYoz+cCDX7KugiygOe0J0YEj+Eh0pQGX+IlOrjl12yiOJ2+g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lodash": "^4.17.23",
@@ -11003,7 +11003,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-watcher-openclaw",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-watcher-openclaw": "dist/cli.js"
@@ -11025,11 +11025,11 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-watcher",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "@karmaniverous/jsonmap": "^2.1.0",
+        "@karmaniverous/jsonmap": "^2.1.1",
         "@langchain/google-genai": "*",
         "@langchain/qdrant": "*",
         "@langchain/textsplitters": "*",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
-    "@karmaniverous/jsonmap": "^2.1.0",
+    "@karmaniverous/jsonmap": "^2.1.1",
     "@langchain/google-genai": "*",
     "@langchain/qdrant": "*",
     "@langchain/textsplitters": "*",


### PR DESCRIPTION
Updates jsonmap to 2.1.1 which removes verbose console.debug logging from JsonMap#transform. All 381 tests pass.