### PR TITLE
fix: update test fixture to include slots for idempotency check

### DIFF
--- a/packages/openclaw/src/cli.test.ts
+++ b/packages/openclaw/src/cli.test.ts
@@ -44,6 +44,7 @@ describe('patchConfig', () => {
         plugins: {
           allow: ['jeeves-watcher-openclaw'],
           entries: { 'jeeves-watcher-openclaw': { enabled: true } },
+          slots: { memory: 'jeeves-watcher-openclaw' },
         },
       };
       const msgs = patchConfig(config, 'add');


### PR DESCRIPTION
Cherry-picked from the merged slot-takeover branch. Adds plugins.slots to the 'does not duplicate if already present' test fixture so patchConfig correctly returns no messages when the plugin is fully installed.