### PR TITLE
fix: plugin config lookup uses correct entry key

### DIFF
--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -64,7 +64,8 @@ export function getWorkspacePath(api: PluginApi): string {
 
 /** Resolve the watcher API base URL from plugin config. */
 export function getApiUrl(api: PluginApi): string {
-  const url = api.config?.plugins?.entries?.['jeeves-watcher']?.config?.apiUrl;
+  const url =
+    api.config?.plugins?.entries?.['jeeves-watcher-openclaw']?.config?.apiUrl;
   return typeof url === 'string' ? url : DEFAULT_API_URL;
 }
 
@@ -102,7 +103,7 @@ export function connectionFail(error: unknown, baseUrl: string): ToolResult {
           text: [
             `Watcher service not reachable at ${baseUrl}.`,
             'Either start the watcher service, or if it runs on a different port,',
-            'set plugins.entries.jeeves-watcher.config.apiUrl in openclaw.json.',
+            'set plugins.entries.jeeves-watcher-openclaw.config.apiUrl in openclaw.json.',
           ].join('\n'),
         },
       ],


### PR DESCRIPTION
getApiUrl() was looking up config under plugins.entries['jeeves-watcher'] but the actual entry key is 'jeeves-watcher-openclaw'. This caused the plugin to always fall back to the default port (3458) regardless of config. Also fixes the error message to reference the correct key.