### PR TITLE
fix: ensure text index on startup + re-register virtual rules after watcher restart

### DIFF
--- a/packages/openclaw/src/memoryTools.test.ts
+++ b/packages/openclaw/src/memoryTools.test.ts
@@ -71,7 +71,7 @@ describe('createMemoryTools', () => {
       fetchMock.mockClear();
 
       await memorySearch('id2', { query: 'second' });
-      expect(fetchMock).toHaveBeenCalledTimes(1); // only search
+      expect(fetchMock).toHaveBeenCalledTimes(2); // status check + search
     });
 
     it('retries init after failure', async () => {

--- a/packages/openclaw/src/memoryTools.ts
+++ b/packages/openclaw/src/memoryTools.ts
@@ -25,6 +25,7 @@ import {
 /** State for lazy init. */
 interface InitState {
   initialized: boolean;
+  lastWatcherUptime: number;
   workspace: string;
   baseUrl: string;
 }
@@ -106,16 +107,22 @@ export function createMemoryTools(api: PluginApi, baseUrl: string) {
   const workspace = getWorkspacePath(api);
   const state: InitState = {
     initialized: false,
+    lastWatcherUptime: 0,
     workspace,
     baseUrl,
   };
 
   /** Lazy init: register virtual rules with watcher. */
   async function ensureInit(): Promise<void> {
-    if (state.initialized) return;
+    // Check watcher is reachable and detect restarts
+    const status = (await fetchJson(`${state.baseUrl}/status`)) as {
+      uptime?: number;
+    };
+    const uptime = status.uptime ?? 0;
 
-    // Check watcher is reachable
-    await fetchJson(`${state.baseUrl}/status`);
+    // If watcher restarted (uptime decreased), re-register virtual rules
+    if (state.initialized && uptime >= state.lastWatcherUptime) return;
+    state.lastWatcherUptime = uptime;
 
     // Clear any stale rules
     await fetchJson(`${state.baseUrl}/rules/unregister`, {

--- a/packages/service/src/app/initialization.ts
+++ b/packages/service/src/app/initialization.ts
@@ -68,6 +68,7 @@ export async function initEmbeddingAndStore(
     logger,
   );
   await vectorStore.ensureCollection();
+  await vectorStore.ensureTextIndex('chunk_text');
 
   return { embeddingProvider, vectorStore };
 }


### PR DESCRIPTION
Two fixes:

1. **Service:** Call ensureTextIndex('chunk_text') during initialization so the Qdrant full-text payload index is created on startup. Previously only ensureCollection() was called, leaving the keyword index unbuilt.

2. **Plugin:** Track watcher uptime and re-register virtual rules when uptime decreases (indicating a service restart). Previously the plugin cached initialized=true and never re-registered after the watcher restarted, leaving virtual rules (memory domain tags) missing.

Service: 381/381 tests pass. Plugin: 40/40 tests pass.