### PR TITLE
fix: use glob instead of pattern for virtual rule matching

### DIFF
--- a/packages/openclaw/src/memoryTools.ts
+++ b/packages/openclaw/src/memoryTools.ts
@@ -38,12 +38,10 @@ function buildVirtualRules(workspace: string) {
       name: 'openclaw-memory-longterm',
       description: 'OpenClaw long-term memory file',
       match: {
-        type: 'object',
         properties: {
           file: {
-            type: 'object',
             properties: {
-              path: { type: 'string', pattern: `^${ws}/MEMORY\\.md$` },
+              path: { glob: `${ws}/MEMORY.md` },
             },
           },
         },
@@ -62,12 +60,10 @@ function buildVirtualRules(workspace: string) {
       name: 'openclaw-memory-daily',
       description: 'OpenClaw daily memory logs',
       match: {
-        type: 'object',
         properties: {
           file: {
-            type: 'object',
             properties: {
-              path: { type: 'string', pattern: `^${ws}/memory/.*\\.md$` },
+              path: { glob: `${ws}/memory/**/*.md` },
             },
           },
         },


### PR DESCRIPTION
Virtual rules used JSON Schema pattern (regex, case-sensitive) which failed on Windows where drive letter case varies. Switches to the glob keyword (picomatch, case-insensitive) matching the static rules' approach. 40/40 tests pass.