### PR TITLE
fix: restore drive letter lowercasing to match watcher path normalization

### DIFF
--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -44,7 +44,11 @@ export const PLUGIN_SOURCE = 'jeeves-watcher-openclaw';
 
 /** Normalize a path to forward slashes and lowercase drive letter on Windows. */
 export function normalizePath(p: string): string {
-  return p.replace(/\\/g, '/');
+  let result = p.replace(/\\/g, '/');
+  if (/^[A-Z]:/.test(result)) {
+    result = result[0].toLowerCase() + result.slice(1);
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
PR #61 removed drive letter lowercasing from normalizePath, but the watcher indexes paths with lowercase drive letters. Restores the lowercasing so virtual rule globs match indexed paths. 40/40 tests pass.