### PR TITLE
fix: case-insensitive glob matching in AJV rule keyword

### DIFF
--- a/packages/service/src/rules/ajvSetup.ts
+++ b/packages/service/src/rules/ajvSetup.ts
@@ -20,7 +20,7 @@ export function createRuleAjv(): Ajv {
     type: 'string',
     schemaType: 'string',
     validate: (pattern: string, data: string) =>
-      picomatch.isMatch(data, pattern),
+      picomatch.isMatch(data, pattern, { dot: true, nocase: true }),
   });
   return ajv;
 }

--- a/packages/service/src/rules/rules.test.ts
+++ b/packages/service/src/rules/rules.test.ts
@@ -81,6 +81,70 @@ describe('rules engine', () => {
     expect(result.metadata).toEqual({});
   });
 
+  it('matches glob patterns case-insensitively (Windows drive letters)', async () => {
+    const rules: InferenceRule[] = [
+      {
+        name: 'case-glob',
+        description: 'Match with different drive-letter casing',
+        match: {
+          properties: {
+            file: {
+              properties: {
+                path: { glob: 'J:/docs/**/*.md' },
+              },
+            },
+          },
+        },
+        schema: [{ properties: { matched: { type: 'string', set: 'yes' } } }],
+      },
+    ];
+    const compiled = compileRules(rules);
+    const attrs = makeAttributes({
+      file: {
+        path: 'j:/docs/readme.md',
+        directory: 'j:/docs',
+        filename: 'readme.md',
+        extension: '.md',
+        sizeBytes: 1024,
+        modified: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    const result = await applyRules(compiled, attrs);
+    expect(result.metadata).toEqual({ matched: 'yes' });
+  });
+
+  it('matches glob patterns with dot files', async () => {
+    const rules: InferenceRule[] = [
+      {
+        name: 'dot-glob',
+        description: 'Match dotfiles',
+        match: {
+          properties: {
+            file: {
+              properties: {
+                path: { glob: 'j:/config/**' },
+              },
+            },
+          },
+        },
+        schema: [{ properties: { matched: { type: 'string', set: 'yes' } } }],
+      },
+    ];
+    const compiled = compileRules(rules);
+    const attrs = makeAttributes({
+      file: {
+        path: 'j:/config/.hidden/test.json',
+        directory: 'j:/config/.hidden',
+        filename: 'test.json',
+        extension: '.json',
+        sizeBytes: 512,
+        modified: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    const result = await applyRules(compiled, attrs);
+    expect(result.metadata).toEqual({ matched: 'yes' });
+  });
+
   it('matches frontmatter properties', async () => {
     const rules: InferenceRule[] = [
       {


### PR DESCRIPTION
## Problem

The \glob\ keyword in \jvSetup.ts\ used \picomatch.isMatch()\ without options, making inference rule matching case-sensitive. On Windows:

- Chokidar emits paths with lowercase drive letters (\j:\) from the watch config
- Plugins register globs with uppercase drive letters (\J:\) from the OpenClaw workspace path
- Case-sensitive match → virtual rules silently fail to match files

This caused \MEMORY.md\ to never receive \domain: memory\ from virtual rules, breaking \memory_search\.

## Fix

Added \{ dot: true, nocase: true }\ to the picomatch call in \createRuleAjv()\, matching the behavior of \uildGlobMatcher\ in the watcher module which already uses these options.

## Tests

- Added case-insensitive drive letter glob test
- Added dotfile glob matching test
- 383 tests pass