### PR TITLE
feat: auto-reapply rules after virtual rule registration

### DIFF
--- a/packages/openclaw/src/memoryTools.test.ts
+++ b/packages/openclaw/src/memoryTools.test.ts
@@ -50,7 +50,7 @@ describe('createMemoryTools', () => {
 
       await memorySearch('id1', { query: 'test' });
 
-      expect(fetchMock).toHaveBeenCalledTimes(4); // status, unregister, register, search
+      expect(fetchMock).toHaveBeenCalledTimes(5); // status, unregister, register, reapply, search
       expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3458/status');
       expect(fetchMock.mock.calls[1][0]).toBe(
         'http://localhost:3458/rules/unregister',
@@ -58,7 +58,10 @@ describe('createMemoryTools', () => {
       expect(fetchMock.mock.calls[2][0]).toBe(
         'http://localhost:3458/rules/register',
       );
-      expect(fetchMock.mock.calls[3][0]).toBe('http://localhost:3458/search');
+      expect(fetchMock.mock.calls[3][0]).toBe(
+        'http://localhost:3458/rules/reapply',
+      );
+      expect(fetchMock.mock.calls[4][0]).toBe('http://localhost:3458/search');
     });
 
     it('skips init on subsequent calls', async () => {
@@ -132,8 +135,9 @@ describe('createMemoryTools', () => {
           },
         },
       ];
-      // Status, unregister, register return ok; search returns results
+      // Status, unregister, register, reapply return ok; search returns results
       fetchMock
+        .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
@@ -169,6 +173,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
+        .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk(searchResults));
 
       const api = makeApi(tempDir);
@@ -193,6 +198,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
+        .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk([]));
 
       const api = makeApi(tempDir);
@@ -200,7 +206,7 @@ describe('createMemoryTools', () => {
 
       await memorySearch('id1', { query: 'test', maxResults: 3 });
 
-      const searchCall = fetchMock.mock.calls[3] as [string, RequestInit];
+      const searchCall = fetchMock.mock.calls[4] as [string, RequestInit];
       const body = JSON.parse(searchCall[1].body as string) as Record<
         string,
         unknown
@@ -222,6 +228,7 @@ describe('createMemoryTools', () => {
         },
       ];
       fetchMock
+        .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())
         .mockResolvedValueOnce(mockFetchOk())

--- a/packages/openclaw/src/memoryTools.ts
+++ b/packages/openclaw/src/memoryTools.ts
@@ -128,10 +128,30 @@ export function createMemoryTools(api: PluginApi, baseUrl: string) {
     });
 
     // Register virtual rules
+    const virtualRules = buildVirtualRules(state.workspace);
     await postJson(`${state.baseUrl}/rules/register`, {
       source: PLUGIN_SOURCE,
-      rules: buildVirtualRules(state.workspace),
+      rules: virtualRules,
     });
+
+    // Re-apply rules to already-indexed files matching virtual rule globs
+    const globs = virtualRules
+      .map((r) => {
+        const path = r.match.properties.file.properties.path as Record<
+          string,
+          unknown
+        >;
+        return typeof path.glob === 'string' ? path.glob : undefined;
+      })
+      .filter((g): g is string => g !== undefined);
+
+    if (globs.length > 0) {
+      try {
+        await postJson(`${state.baseUrl}/rules/reapply`, { globs });
+      } catch {
+        // Non-fatal: files will get correct rules on next change
+      }
+    }
 
     state.initialized = true;
   }

--- a/packages/service/src/api/handlers/rulesReapply.ts
+++ b/packages/service/src/api/handlers/rulesReapply.ts
@@ -1,0 +1,82 @@
+/**
+ * @module api/handlers/rulesReapply
+ * Fastify route handler for POST /rules/reapply.
+ * Re-applies current inference rules to already-indexed files matching given globs.
+ */
+
+import type { FastifyRequest } from 'fastify';
+import picomatch from 'picomatch';
+import type pino from 'pino';
+
+import type { DocumentProcessorInterface } from '../../processor';
+import { normalizeSlashes } from '../../util/normalizeSlashes';
+import type { VectorStore } from '../../vectorStore';
+import { wrapHandler } from './wrapHandler';
+
+export interface RulesReapplyDeps {
+  processor: DocumentProcessorInterface;
+  vectorStore: VectorStore;
+  logger: pino.Logger;
+}
+
+type ReapplyRequest = FastifyRequest<{
+  Body: { globs: string[] };
+}>;
+
+/**
+ * Create handler for POST /rules/reapply.
+ *
+ * Scrolls through all indexed points, finds files matching the given globs,
+ * and re-applies current inference rules without re-embedding.
+ */
+export function createRulesReapplyHandler(deps: RulesReapplyDeps) {
+  return wrapHandler(
+    async (request: ReapplyRequest) => {
+      await Promise.resolve();
+      const { globs } = request.body;
+
+      if (!Array.isArray(globs) || globs.length === 0) {
+        throw new Error(
+          'Missing required field: globs (non-empty string array)',
+        );
+      }
+
+      const normalizedGlobs = globs.map((g) => normalizeSlashes(g));
+      const isMatch = picomatch(normalizedGlobs, { dot: true, nocase: true });
+
+      // Collect unique file paths matching the globs
+      const matchingFiles = new Set<string>();
+      for await (const point of deps.vectorStore.scroll()) {
+        const filePath = point.payload['file_path'];
+        if (typeof filePath === 'string' && isMatch(filePath)) {
+          matchingFiles.add(filePath);
+        }
+      }
+
+      deps.logger.info(
+        { globs: normalizedGlobs, matchCount: matchingFiles.size },
+        'Re-applying rules to matching files',
+      );
+
+      let updated = 0;
+      for (const filePath of matchingFiles) {
+        try {
+          const result = await deps.processor.processRulesUpdate(filePath);
+          if (result !== null) updated++;
+        } catch (error) {
+          deps.logger.warn(
+            { filePath, err: error },
+            'Failed to re-apply rules to file',
+          );
+        }
+      }
+
+      return {
+        matched: matchingFiles.size,
+        updated,
+      };
+    },
+    deps.logger,
+    'RulesReapply',
+  );
+}

--- a/packages/service/src/api/index.ts
+++ b/packages/service/src/api/index.ts
@@ -28,6 +28,7 @@ import { createMetadataHandler } from './handlers/metadata';
 import { createPointsDeleteHandler } from './handlers/pointsDelete';
 import { createRebuildMetadataHandler } from './handlers/rebuildMetadata';
 import { createReindexHandler } from './handlers/reindex';
+import { createRulesReapplyHandler } from './handlers/rulesReapply';
 import { createRulesRegisterHandler } from './handlers/rulesRegister';
 import {
   createRulesUnregisterHandler,
@@ -227,6 +228,11 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     app.post(
       '/points/delete',
       createPointsDeleteHandler({ vectorStore, logger }),
+    );
+
+    app.post(
+      '/rules/reapply',
+      createRulesReapplyHandler({ processor, vectorStore, logger }),
     );
   }
 

--- a/packages/service/src/processor/index.ts
+++ b/packages/service/src/processor/index.ts
@@ -317,7 +317,10 @@ export class DocumentProcessor implements DocumentProcessorInterface {
       this.config = { ...this.config, customMapLib };
     }
     this.logger.info(
-      { rules: compiledRules.length },
+      {
+        rules: compiledRules.length,
+        ruleNames: compiledRules.map((r) => r.rule.name),
+      },
       'Inference rules updated',
     );
   }


### PR DESCRIPTION
## Problem

Virtual rules registered after the initial file scan don't take effect on already-indexed files. This is a race condition:

1. Watcher starts with \ignoreInitial: false\ → chokidar fires \dd\ events for all existing files
2. Files like \MEMORY.md\ get processed with only static config rules (38 rules)
3. Plugin registers virtual rules via \POST /rules/register\ (now 40 rules)
4. Files processed BEFORE registration never get virtual rule metadata

This caused \MEMORY.md\ to miss \domain: memory\ from virtual rules, breaking \memory_search\ results for it.

## Fix

### Service: \POST /rules/reapply\ endpoint
- Accepts \{ globs: string[] }\
- Scrolls all indexed points, finds files matching globs (picomatch, nocase)
- Calls \processRulesUpdate()\ for each match (re-applies rules without re-embedding)

### Plugin: auto-reapply after registration
- After registering virtual rules, extracts glob patterns from the rules
- Calls \/rules/reapply\ with those globs
- Failure is non-fatal (files get correct rules on next change)

## Tests
- 383 service tests pass
- 40 plugin tests pass (mock sequences updated for new reapply call)