### PR TITLE
fix: fresh QdrantClient for write ops to avoid stale keep-alive ECONNRESET

### DIFF
--- a/packages/service/src/vectorStore/index.ts
+++ b/packages/service/src/vectorStore/index.ts
@@ -36,6 +36,7 @@ export type {
  */
 export class VectorStoreClient implements VectorStore {
   private readonly client: QdrantClient;
+  private readonly clientConfig: { url: string; apiKey?: string };
   private readonly collectionName: string;
   private readonly dims: number;
   private readonly log: MinimalLogger;
@@ -53,15 +54,27 @@ export class VectorStoreClient implements VectorStore {
     dimensions: number,
     logger?: pino.Logger,
   ) {
-    this.client = new QdrantClient({
-      url: config.url,
-      apiKey: config.apiKey,
-      checkCompatibility: false,
-    });
+    this.clientConfig = { url: config.url, apiKey: config.apiKey };
+    this.client = this.createClient();
     this.collectionName = config.collectionName;
     this.dims = dimensions;
     this.log = getLogger(logger);
     this.pinoLogger = logger;
+  }
+
+  /**
+   * Create a fresh QdrantClient instance.
+   *
+   * Used to avoid stale HTTP keep-alive connections. The Qdrant JS client's
+   * internal undici Agent uses keepAliveTimeout: 10s, which causes ECONNRESET
+   * when connections sit idle during slow embedding calls (Gemini p99 ~8s).
+   * Creating a fresh client for write operations ensures clean TCP connections.
+   */
+  private createClient(): QdrantClient {
+    return new QdrantClient({
+      ...this.clientConfig,
+      checkCompatibility: false,
+    });
   }
 
   /**
@@ -128,13 +141,18 @@ export class VectorStoreClient implements VectorStore {
   /**
    * Upsert points into the collection.
    *
+   * Uses a fresh QdrantClient per attempt to avoid stale keep-alive connections.
+   * Between embedding calls and upserts, idle connections may be closed by the
+   * server, causing ECONNRESET on reuse.
+   *
    * @param points - The points to upsert.
    */
   async upsert(points: VectorPoint[]): Promise<void> {
     if (points.length === 0) return;
 
     await this.retryOperation('upsert', async () => {
-      await this.client.upsert(this.collectionName, {
+      const freshClient = this.createClient();
+      await freshClient.upsert(this.collectionName, {
         wait: true,
         points: points.map((p) => ({
           id: p.id,
@@ -148,13 +166,16 @@ export class VectorStoreClient implements VectorStore {
   /**
    * Delete points by their IDs.
    *
+   * Uses a fresh QdrantClient per attempt to avoid stale keep-alive connections.
+   *
    * @param ids - The point IDs to delete.
    */
   async delete(ids: string[]): Promise<void> {
     if (ids.length === 0) return;
 
     await this.retryOperation('delete', async () => {
-      await this.client.delete(this.collectionName, {
+      const freshClient = this.createClient();
+      await freshClient.delete(this.collectionName, {
         wait: true,
         points: ids,
       });


### PR DESCRIPTION
## Problem

The Qdrant JS client's internal undici Agent uses `keepAliveTimeout: 10s`. When embedding calls take longer (Gemini p99 ~8s), idle HTTP keep-alive connections go stale and cause `ECONNRESET` on the subsequent Qdrant upsert. Under load (full reindex), this causes 30-65% of file processing operations to fail.

## Root Cause

The pipeline flow is: `file -> chunk -> embed (Google API, 2-8s) -> upsert (Qdrant)`. During the embedding step, the pooled Qdrant TCP connection sits idle. If the server or OS closes it before the client's keepAliveTimeout, the next upsert hits a half-open connection.

The `@qdrant/js-client-rest` library hardcodes `keepAliveTimeout: 10000` in its internal undici Agent (`dispatcher.js`), and doesn't expose this as a constructor option.

## Fix

`VectorStoreClient` now creates a fresh `QdrantClient` for each upsert/delete attempt via `createClient()`. This ensures every write operation gets a clean TCP connection. Read operations (search, getPayload, setPayload) still use the persistent client since they execute in tight sequences without long embedding gaps.

## Impact

- **Files changed:** 1 (`packages/service/src/vectorStore/index.ts`)
- **Tests:** 383 pass
- **Blast area:** Transport-layer only. No API, config, or behavioral changes.