### PR TITLE
feat(openclaw): decouple plugin from watcher config vocabulary

### DIFF
--- a/packages/openclaw/src/helpers.test.ts
+++ b/packages/openclaw/src/helpers.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchJson, postJson } from './helpers.js';
+import { fetchJson, getPluginSchemas, type PluginApi, postJson } from './helpers.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -31,6 +31,66 @@ describe('fetchJson', () => {
     await expect(fetchJson('http://example.com/api')).rejects.toThrow(
       'HTTP 500: Internal Server Error',
     );
+  });
+});
+
+describe('getPluginSchemas', () => {
+  it('returns empty object when no schemas config', () => {
+    const api: PluginApi = { registerTool: () => {} };
+    expect(getPluginSchemas(api)).toEqual({});
+  });
+
+  it('normalizes single object to array', () => {
+    const schema = { type: 'object', properties: { domains: { set: ['memory'] } } };
+    const api: PluginApi = {
+      config: {
+        plugins: {
+          entries: {
+            'jeeves-watcher-openclaw': {
+              config: { schemas: { 'openclaw-memory-longterm': schema } },
+            },
+          },
+        },
+      },
+      registerTool: () => {},
+    };
+    const result = getPluginSchemas(api);
+    expect(result['openclaw-memory-longterm']).toEqual([schema]);
+  });
+
+  it('passes arrays through', () => {
+    const schemas = [{ type: 'object' }, { type: 'object' }];
+    const api: PluginApi = {
+      config: {
+        plugins: {
+          entries: {
+            'jeeves-watcher-openclaw': {
+              config: { schemas: { 'openclaw-memory-daily': schemas } },
+            },
+          },
+        },
+      },
+      registerTool: () => {},
+    };
+    const result = getPluginSchemas(api);
+    expect(result['openclaw-memory-daily']).toHaveLength(2);
+  });
+
+  it('normalizes string references to array', () => {
+    const api: PluginApi = {
+      config: {
+        plugins: {
+          entries: {
+            'jeeves-watcher-openclaw': {
+              config: { schemas: { 'openclaw-memory-longterm': 'my-named-schema' } },
+            },
+          },
+        },
+      },
+      registerTool: () => {},
+    };
+    const result = getPluginSchemas(api);
+    expect(result['openclaw-memory-longterm']).toEqual(['my-named-schema']);
   });
 });
 

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -65,6 +65,41 @@ export function getApiUrl(api: PluginApi): string {
   return typeof url === 'string' ? url : DEFAULT_API_URL;
 }
 
+/**
+ * Schema value type — matches watcher inference rule schema conventions.
+ * Can be an inline JSON Schema object, a file reference string,
+ * a named schema reference, or a composable array of these.
+ */
+export type SchemaValue =
+  | Record<string, unknown>
+  | string
+  | Array<Record<string, unknown> | string>;
+
+/**
+ * Resolve user-supplied schemas from plugin config.
+ * Returns a map of rule name → schema array (always normalized to array).
+ */
+export function getPluginSchemas(
+  api: PluginApi,
+): Record<string, Array<Record<string, unknown> | string>> {
+  const config =
+    api.config?.plugins?.entries?.['jeeves-watcher-openclaw']?.config;
+  const raw = config?.schemas as
+    | Record<string, SchemaValue>
+    | undefined;
+  if (!raw || typeof raw !== 'object') return {};
+
+  const result: Record<string, Array<Record<string, unknown> | string>> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) {
+      result[name] = value as Array<Record<string, unknown> | string>;
+    } else if (typeof value === 'object' || typeof value === 'string') {
+      result[name] = [value as Record<string, unknown> | string];
+    }
+  }
+  return result;
+}
+
 /** Format a successful tool result. */
 export function ok(data: unknown): ToolResult {
   return {

--- a/packages/openclaw/src/memoryTools.test.ts
+++ b/packages/openclaw/src/memoryTools.test.ts
@@ -5,16 +5,35 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PluginApi } from './helpers.js';
-import { createMemoryTools } from './memoryTools.js';
+import {
+  createMemoryTools,
+  PROP_KIND,
+  PROP_SOURCE,
+  RULE_DAILY,
+  RULE_LONGTERM,
+  SOURCE_MEMORY,
+} from './memoryTools.js';
 
 // Mock fetch globally
 const fetchMock = vi.fn();
 vi.stubGlobal('fetch', fetchMock);
 
-function makeApi(workspace: string): PluginApi {
+function makeApi(
+  workspace: string,
+  schemas?: Record<string, unknown>,
+): PluginApi {
   return {
     config: {
       agents: { defaults: { workspace } },
+      plugins: schemas
+        ? {
+            entries: {
+              'jeeves-watcher-openclaw': {
+                config: { schemas },
+              },
+            },
+          }
+        : undefined,
     },
     registerTool: () => {},
   };
@@ -97,7 +116,7 @@ describe('createMemoryTools', () => {
       expect(result2.isError).toBeUndefined();
     });
 
-    it('registers rules with correct workspace paths', async () => {
+    it('registers rules with private namespaced properties', async () => {
       fetchMock.mockResolvedValue(mockFetchOk([]));
 
       const api = makeApi(tempDir);
@@ -112,12 +131,59 @@ describe('createMemoryTools', () => {
       ];
       const body = JSON.parse(registerCall[1].body) as {
         source: string;
-        rules: Array<{ name: string }>;
+        rules: Array<{
+          name: string;
+          schema: Array<Record<string, unknown>>;
+        }>;
       };
       expect(body.source).toBe('jeeves-watcher-openclaw');
       expect(body.rules).toHaveLength(2);
-      expect(body.rules[0].name).toBe('openclaw-memory-longterm');
-      expect(body.rules[1].name).toBe('openclaw-memory-daily');
+      expect(body.rules[0].name).toBe(RULE_LONGTERM);
+      expect(body.rules[1].name).toBe(RULE_DAILY);
+
+      // Verify internal schema uses private properties, NOT domains/kind
+      const longtermSchema = body.rules[0].schema[0] as {
+        properties: Record<string, unknown>;
+      };
+      expect(longtermSchema.properties).toHaveProperty(PROP_SOURCE);
+      expect(longtermSchema.properties).toHaveProperty(PROP_KIND);
+      expect(longtermSchema.properties).not.toHaveProperty('domains');
+      expect(longtermSchema.properties).not.toHaveProperty('kind');
+    });
+
+    it('composes user schemas from plugin config', async () => {
+      fetchMock.mockResolvedValue(mockFetchOk([]));
+
+      const userSchema = {
+        type: 'object',
+        properties: {
+          domains: {
+            type: 'array',
+            items: { type: 'string' },
+            set: ['memory'],
+          },
+        },
+      };
+      const api = makeApi(tempDir, {
+        [RULE_LONGTERM]: userSchema,
+        [RULE_DAILY]: [userSchema],
+      });
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+
+      await memorySearch('id1', { query: 'test' });
+
+      const registerCall = fetchMock.mock.calls[2] as [
+        string,
+        { body: string },
+      ];
+      const body = JSON.parse(registerCall[1].body) as {
+        rules: Array<{ schema: unknown[] }>;
+      };
+
+      // Longterm: internal schema + 1 user schema = 2 entries
+      expect(body.rules[0].schema).toHaveLength(2);
+      // Daily: internal schema + 1 user schema (from array) = 2 entries
+      expect(body.rules[1].schema).toHaveLength(2);
     });
   });
 
@@ -191,6 +257,27 @@ describe('createMemoryTools', () => {
       });
       expect(parsed[0]).not.toHaveProperty('from');
       expect(parsed[0]).not.toHaveProperty('to');
+    });
+
+    it('filters on private source property, not domains', async () => {
+      fetchMock
+        .mockResolvedValueOnce(mockFetchOk())
+        .mockResolvedValueOnce(mockFetchOk())
+        .mockResolvedValueOnce(mockFetchOk())
+        .mockResolvedValueOnce(mockFetchOk())
+        .mockResolvedValueOnce(mockFetchOk([]));
+
+      const api = makeApi(tempDir);
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+
+      await memorySearch('id1', { query: 'test' });
+
+      const searchCall = fetchMock.mock.calls[4] as [string, RequestInit];
+      const body = JSON.parse(searchCall[1].body as string) as {
+        filter: { must: Array<{ key: string; match: { value: string } }> };
+      };
+      expect(body.filter.must[0].key).toBe(PROP_SOURCE);
+      expect(body.filter.must[0].match.value).toBe(SOURCE_MEMORY);
     });
 
     it('forwards maxResults as limit in search body', async () => {

--- a/packages/openclaw/src/memoryTools.ts
+++ b/packages/openclaw/src/memoryTools.ts
@@ -13,6 +13,7 @@ import {
   connectionFail,
   fail,
   fetchJson,
+  getPluginSchemas,
   getWorkspacePath,
   normalizePath,
   ok,
@@ -30,12 +31,52 @@ interface InitState {
   baseUrl: string;
 }
 
-/** Build virtual inference rules for a workspace path. */
-function buildVirtualRules(workspace: string) {
+/** Private property prefix — namespaces plugin metadata to avoid collisions. */
+const PROP_PREFIX = '_jeeves_watcher_openclaw_';
+
+/** Private property keys used by the plugin for filtering. */
+export const PROP_SOURCE = `${PROP_PREFIX}source_`;
+export const PROP_KIND = `${PROP_PREFIX}kind_`;
+
+/** Memory source value for filter queries. */
+export const SOURCE_MEMORY = 'memory';
+
+/** Virtual rule names (exported for testing and config reference). */
+export const RULE_LONGTERM = 'openclaw-memory-longterm';
+export const RULE_DAILY = 'openclaw-memory-daily';
+
+/**
+ * Build virtual inference rules for a workspace path.
+ *
+ * Each rule's schema is composed of:
+ * 1. Plugin-internal schema (private namespaced properties, no uiHint)
+ * 2. User-supplied schemas from plugin config (optional, owner-controlled)
+ */
+function buildVirtualRules(
+  workspace: string,
+  userSchemas: Record<string, Array<Record<string, unknown> | string>>,
+) {
   const ws = normalizePath(workspace);
+
+  const longtermInternal = {
+    type: 'object' as const,
+    properties: {
+      [PROP_SOURCE]: { type: 'string', set: SOURCE_MEMORY },
+      [PROP_KIND]: { type: 'string', set: 'long-term' },
+    },
+  };
+
+  const dailyInternal = {
+    type: 'object' as const,
+    properties: {
+      [PROP_SOURCE]: { type: 'string', set: SOURCE_MEMORY },
+      [PROP_KIND]: { type: 'string', set: 'daily-log' },
+    },
+  };
+
   return [
     {
-      name: 'openclaw-memory-longterm',
+      name: RULE_LONGTERM,
       description: 'OpenClaw long-term memory file',
       match: {
         properties: {
@@ -47,21 +88,12 @@ function buildVirtualRules(workspace: string) {
         },
       },
       schema: [
-        {
-          type: 'object',
-          properties: {
-            domains: {
-              type: 'array',
-              items: { type: 'string' },
-              set: ['memory'],
-            },
-            kind: { type: 'string', set: 'long-term' },
-          },
-        },
+        longtermInternal,
+        ...(userSchemas[RULE_LONGTERM] ?? []),
       ],
     },
     {
-      name: 'openclaw-memory-daily',
+      name: RULE_DAILY,
       description: 'OpenClaw daily memory logs',
       match: {
         properties: {
@@ -73,17 +105,8 @@ function buildVirtualRules(workspace: string) {
         },
       },
       schema: [
-        {
-          type: 'object',
-          properties: {
-            domains: {
-              type: 'array',
-              items: { type: 'string' },
-              set: ['memory'],
-            },
-            kind: { type: 'string', set: 'daily-log' },
-          },
-        },
+        dailyInternal,
+        ...(userSchemas[RULE_DAILY] ?? []),
       ],
     },
   ];
@@ -109,6 +132,7 @@ function isAllowedMemoryPath(filePath: string, workspace: string): boolean {
  */
 export function createMemoryTools(api: PluginApi, baseUrl: string) {
   const workspace = getWorkspacePath(api);
+  const userSchemas = getPluginSchemas(api);
   const state: InitState = {
     initialized: false,
     lastWatcherUptime: 0,
@@ -136,7 +160,7 @@ export function createMemoryTools(api: PluginApi, baseUrl: string) {
     });
 
     // Register virtual rules
-    const virtualRules = buildVirtualRules(state.workspace);
+    const virtualRules = buildVirtualRules(state.workspace, userSchemas);
     await postJson(`${state.baseUrl}/rules/register`, {
       source: PLUGIN_SOURCE,
       rules: virtualRules,
@@ -174,7 +198,7 @@ export function createMemoryTools(api: PluginApi, baseUrl: string) {
       const body: Record<string, unknown> = {
         query: params.query,
         filter: {
-          must: [{ key: 'domains', match: { value: 'memory' } }],
+          must: [{ key: PROP_SOURCE, match: { value: SOURCE_MEMORY } }],
         },
       };
       if (params.maxResults !== undefined) body.limit = params.maxResults;


### PR DESCRIPTION
## Summary

Replace \domains\/\kind\ in virtual rule schemas with private namespaced properties (\_jeeves_watcher_openclaw_source_\, \_jeeves_watcher_openclaw_kind_\). Plugin's \memory_search\ now filters on its own private properties, eliminating coupling to instance-specific watcher config vocabulary.

## Plugin Config \schemas\ Key

Adds optional \schemas\ in plugin config for owner to bridge plugin rules to their watcher vocabulary:

\\\json
{
  apiUrl: http://127.0.0.1:3459,
  schemas: {
    openclaw-memory-longterm: {
      type: object,
      properties: {
        domains: { type: array, items: { type: string }, set: [memory] }
      }
    }
  }
}
\\\

Schema values follow standard watcher conventions (inline object, file ref, named ref, or composable array).

## Changes

- **helpers.ts**: \getPluginSchemas()\ + \SchemaValue\ type
- **memoryTools.ts**: private properties in \uildVirtualRules()\, schema composition, updated search filter
- **Tests**: 46 pass (6 new), typecheck clean, build clean

## Verified

Tested live against prod Qdrant (164K+ points):
- Registered virtual rules with private properties
- Reapply touched 38 memory files
- \memory_search\ with private property filter returned 10 results
- Points carry correct \_jeeves_watcher_openclaw_source_\ and \_jeeves_watcher_openclaw_kind_\ values