### PR TITLE
fix: read CLI version from package.json instead of hardcoding

### DIFF
--- a/packages/service/src/cli/jeeves-watcher/index.ts
+++ b/packages/service/src/cli/jeeves-watcher/index.ts
@@ -4,6 +4,8 @@
  * jeeves-watcher CLI entrypoint.
  */
 
+import { createRequire } from 'node:module';
+
 import { Command } from '@commander-js/extra-typings';
 
 import { startFromConfig } from '../../app';
@@ -22,12 +24,15 @@ import { registerServiceCommand } from './commands/service';
 import { registerStatusCommand } from './commands/status';
 import { writeJsonFile } from './writeJsonFile';
 
+const require = createRequire(import.meta.url);
+const { version } = require('../../../package.json') as { version: string };
+
 const cli = new Command()
   .name('jeeves-watcher')
   .description(
     'Filesystem watcher that keeps a Qdrant vector store in sync with document changes',
   )
-  .version('0.7.0');
+  .version(version);
 
 cli
   .command('start')


### PR DESCRIPTION
The CLI was hardcoded to report v0.7.0 regardless of actual package version. Uses createRequire to read version from package.json at runtime.

One-line fix in \packages/service/src/cli/jeeves-watcher/index.ts\.

Note: 3 pre-existing typecheck errors on main (ajvSetup, mdast-util-to-markdown) — not introduced by this change.