### PR TITLE
chore: change default port from 3456 to 1936

### DIFF
--- a/packages/openclaw/skills/jeeves-watcher/SKILL.md
+++ b/packages/openclaw/skills/jeeves-watcher/SKILL.md
@@ -13,12 +13,12 @@ description: >
 
 The watcher is an HTTP API running as a background service (typically NSSM on Windows, systemd on Linux).
 
-**Default port:** 3458 (configurable via `api.port` in watcher config)
+**Default port:** 1936 (configurable via `api.port` in watcher config)
 **Non-default port:** If the watcher runs on a different port, the user must set `plugins.entries.jeeves-watcher.config.apiUrl` in `openclaw.json`. The plugin cannot auto-discover a non-default port.
 
 **Health check:** `GET /status` returns uptime, point count, collection dimensions, and reindex status.
 
-**Mental model:** The `watcher_*` tools are thin HTTP wrappers. Each tool call translates to an HTTP request to the watcher API. When tools are available, use them. When they're not (e.g., different session, plugin not loaded), you can hit the API directly. Replace `<PORT>` below with the configured port (default 3458; check `plugins.entries.jeeves-watcher.config.apiUrl` in `openclaw.json` if overridden):
+**Mental model:** The `watcher_*` tools are thin HTTP wrappers. Each tool call translates to an HTTP request to the watcher API. When tools are available, use them. When they're not (e.g., different session, plugin not loaded), you can hit the API directly. Replace `<PORT>` below with the configured port (default 1936; check `plugins.entries.jeeves-watcher.config.apiUrl` in `openclaw.json` if overridden):
 
 ```
 # Health check
@@ -589,7 +589,7 @@ If the watcher is unreachable:
 If tools are unavailable (plugin not loaded in this session):
 - The watcher API is still accessible via direct HTTP calls
 - Use `exec` to call the endpoints listed in Service Architecture
-- Default: `http://127.0.0.1:3458`
+- Default: `http://127.0.0.1:1936`
 
 **CLI Fallbacks:**
 - `jeeves-watcher status` — check if the service is running

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -37,7 +37,7 @@ export interface ToolResult {
   isError?: boolean;
 }
 
-const DEFAULT_API_URL = 'http://127.0.0.1:3458';
+const DEFAULT_API_URL = 'http://127.0.0.1:1936';
 
 /** Source identifier for virtual rule registration. */
 export const PLUGIN_SOURCE = 'jeeves-watcher-openclaw';

--- a/packages/openclaw/src/index.test.ts
+++ b/packages/openclaw/src/index.test.ts
@@ -10,7 +10,7 @@ describe('register', () => {
       config: {
         plugins: {
           entries: {
-            'jeeves-watcher': { config: { apiUrl: 'http://localhost:3458' } },
+            'jeeves-watcher': { config: { apiUrl: 'http://localhost:1936' } },
           },
         },
       },

--- a/packages/openclaw/src/memoryTools.test.ts
+++ b/packages/openclaw/src/memoryTools.test.ts
@@ -65,29 +65,29 @@ describe('createMemoryTools', () => {
       fetchMock.mockResolvedValue(mockFetchOk([]));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       await memorySearch('id1', { query: 'test' });
 
       expect(fetchMock).toHaveBeenCalledTimes(5); // status, unregister, register, reapply, search
-      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3458/status');
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:1936/status');
       expect(fetchMock.mock.calls[1][0]).toBe(
-        'http://localhost:3458/rules/unregister',
+        'http://localhost:1936/rules/unregister',
       );
       expect(fetchMock.mock.calls[2][0]).toBe(
-        'http://localhost:3458/rules/register',
+        'http://localhost:1936/rules/register',
       );
       expect(fetchMock.mock.calls[3][0]).toBe(
-        'http://localhost:3458/rules/reapply',
+        'http://localhost:1936/rules/reapply',
       );
-      expect(fetchMock.mock.calls[4][0]).toBe('http://localhost:3458/search');
+      expect(fetchMock.mock.calls[4][0]).toBe('http://localhost:1936/search');
     });
 
     it('skips init on subsequent calls', async () => {
       fetchMock.mockResolvedValue(mockFetchOk([]));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       await memorySearch('id1', { query: 'first' });
       fetchMock.mockClear();
@@ -104,7 +104,7 @@ describe('createMemoryTools', () => {
       );
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       // First call fails
       const result1 = await memorySearch('id1', { query: 'test' });
@@ -120,7 +120,7 @@ describe('createMemoryTools', () => {
       fetchMock.mockResolvedValue(mockFetchOk([]));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       await memorySearch('id1', { query: 'test' });
 
@@ -168,7 +168,7 @@ describe('createMemoryTools', () => {
         [RULE_LONGTERM]: userSchema,
         [RULE_DAILY]: [userSchema],
       });
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       await memorySearch('id1', { query: 'test' });
 
@@ -210,7 +210,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk(searchResults));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memorySearch('id1', { query: 'test' });
       const parsed = JSON.parse(result.content[0].text) as {
@@ -245,7 +245,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk(searchResults));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memorySearch('id1', { query: 'test' });
       const parsed = JSON.parse(result.content[0].text) as {
@@ -272,7 +272,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk([]));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       await memorySearch('id1', { query: 'test' });
 
@@ -293,7 +293,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk([]));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       await memorySearch('id1', { query: 'test', maxResults: 3 });
 
@@ -326,7 +326,7 @@ describe('createMemoryTools', () => {
         .mockResolvedValueOnce(mockFetchOk(searchResults));
 
       const api = makeApi(tempDir);
-      const { memorySearch } = createMemoryTools(api, 'http://localhost:3458');
+      const { memorySearch } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memorySearch('id1', {
         query: 'test',
@@ -347,7 +347,7 @@ describe('createMemoryTools', () => {
       await writeFile(filePath, 'Line 1\nLine 2\nLine 3\n');
 
       const api = makeApi(tempDir);
-      const { memoryGet } = createMemoryTools(api, 'http://localhost:3458');
+      const { memoryGet } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memoryGet('id1', { path: filePath });
       expect(result.isError).toBeUndefined();
@@ -364,7 +364,7 @@ describe('createMemoryTools', () => {
       await writeFile(filePath, 'Line 1\nLine 2\nLine 3\nLine 4\n');
 
       const api = makeApi(tempDir);
-      const { memoryGet } = createMemoryTools(api, 'http://localhost:3458');
+      const { memoryGet } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memoryGet('id1', {
         path: filePath,
@@ -387,7 +387,7 @@ describe('createMemoryTools', () => {
       await writeFile(filePath, 'Daily notes');
 
       const api = makeApi(tempDir);
-      const { memoryGet } = createMemoryTools(api, 'http://localhost:3458');
+      const { memoryGet } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memoryGet('id1', { path: filePath });
       expect(result.isError).toBeUndefined();
@@ -395,7 +395,7 @@ describe('createMemoryTools', () => {
 
     it('rejects paths outside workspace', async () => {
       const api = makeApi(tempDir);
-      const { memoryGet } = createMemoryTools(api, 'http://localhost:3458');
+      const { memoryGet } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memoryGet('id1', {
         path: '/etc/passwd',
@@ -406,7 +406,7 @@ describe('createMemoryTools', () => {
 
     it('rejects non-md files in memory directory', async () => {
       const api = makeApi(tempDir);
-      const { memoryGet } = createMemoryTools(api, 'http://localhost:3458');
+      const { memoryGet } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memoryGet('id1', {
         path: join(tempDir, 'memory', 'secret.txt'),
@@ -416,7 +416,7 @@ describe('createMemoryTools', () => {
 
     it('rejects files outside memory/ subdirectory', async () => {
       const api = makeApi(tempDir);
-      const { memoryGet } = createMemoryTools(api, 'http://localhost:3458');
+      const { memoryGet } = createMemoryTools(api, 'http://localhost:1936');
 
       const result = await memoryGet('id1', {
         path: join(tempDir, 'other.md'),

--- a/packages/openclaw/src/watcherTools.test.ts
+++ b/packages/openclaw/src/watcherTools.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PluginApi, ToolResult } from './helpers.js';
 import { registerWatcherTools } from './watcherTools.js';
 
-const BASE = 'http://localhost:3458';
+const BASE = 'http://localhost:1936';
 
 function mockFetch(data: unknown = {}) {
   return vi.fn().mockResolvedValue({

--- a/packages/service/src/cli/jeeves-watcher/commands/commands-advanced.test.ts
+++ b/packages/service/src/cli/jeeves-watcher/commands/commands-advanced.test.ts
@@ -62,7 +62,7 @@ describe('configReindex command', () => {
     ]);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://127.0.0.1:3456/config-reindex',
+      'http://127.0.0.1:1936/config-reindex',
       expect.objectContaining({
         body: JSON.stringify({ scope: 'rules' }),
       }),
@@ -143,7 +143,7 @@ describe('rebuildMetadata command', () => {
     await cli.parseAsync(['node', 'test', 'rebuild-metadata']);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://127.0.0.1:3456/rebuild-metadata',
+      'http://127.0.0.1:1936/rebuild-metadata',
       expect.objectContaining({ method: 'POST' }),
     );
     expect(consoleLogSpy).toHaveBeenCalledWith('Metadata rebuild started');

--- a/packages/service/src/cli/jeeves-watcher/commands/commands-basic.test.ts
+++ b/packages/service/src/cli/jeeves-watcher/commands/commands-basic.test.ts
@@ -57,7 +57,7 @@ describe('status command', () => {
     await cli.parseAsync(['node', 'test', 'status']);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://127.0.0.1:3456/status',
+      'http://127.0.0.1:1936/status',
       expect.objectContaining({ method: 'GET' }),
     );
     expect(consoleLogSpy).toHaveBeenCalledWith(
@@ -144,7 +144,7 @@ describe('search command', () => {
     ]);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://127.0.0.1:3456/search',
+      'http://127.0.0.1:1936/search',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ query: 'test query', limit: 5 }),
@@ -207,7 +207,7 @@ describe('reindex command', () => {
     await cli.parseAsync(['node', 'test', 'reindex']);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://127.0.0.1:3456/reindex',
+      'http://127.0.0.1:1936/reindex',
       expect.objectContaining({ method: 'POST' }),
     );
     expect(consoleLogSpy).toHaveBeenCalledWith('Reindex started');

--- a/packages/service/src/cli/jeeves-watcher/defaults.ts
+++ b/packages/service/src/cli/jeeves-watcher/defaults.ts
@@ -7,4 +7,4 @@
 export const DEFAULT_HOST = '127.0.0.1';
 
 /** Default API port for CLI commands. */
-export const DEFAULT_PORT = '3456';
+export const DEFAULT_PORT = '1936';

--- a/packages/service/src/config/defaults.ts
+++ b/packages/service/src/config/defaults.ts
@@ -20,7 +20,7 @@ export const CONFIG_WATCH_DEFAULTS = {
 /** Default API values. */
 export const API_DEFAULTS = {
   host: '127.0.0.1',
-  port: 3456,
+  port: 1936,
 };
 
 /** Default logging values. */

--- a/packages/service/src/config/loadConfig.test.ts
+++ b/packages/service/src/config/loadConfig.test.ts
@@ -65,7 +65,7 @@ describe('loadConfig', () => {
     expect(config.watch.paths).toEqual(['**/*.md']);
     // Defaults should be applied
     expect(config.api?.host).toBe('127.0.0.1');
-    expect(config.api?.port).toBe(3456);
+    expect(config.api?.port).toBe(1936);
     expect(config.logging?.level).toBe('info');
   });
 


### PR DESCRIPTION
Part of the 1930s port namespace migration.

**Changes:**
- Service API default port: 3456 → 1936
- CLI default port: 3456 → 1936
- Plugin default API URL: http://127.0.0.1:3458 → http://127.0.0.1:1936
- Skill doc port references updated
- All test fixtures updated

**Port namespace:**
| Service | Port |
|---------|------|
| jeeves-server | 1934 |
| jeeves-watcher | 1936 |
| jeeves-runner | 1937 |

**Tests:** 383/383 service + 54/54 plugin pass.