### PR TITLE
fix(openclaw): align registerHook opts type with OpenClawPluginHookOptions

### DIFF
--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -30,6 +30,11 @@ export interface PluginApi {
   registerHook?: (
     event: string | string[],
     handler: (event: unknown) => Promise<void> | void,
+    opts?: {
+      name?: string;
+      description?: string;
+      register?: boolean;
+    },
   ) => void;
 }
 


### PR DESCRIPTION
Aligns the plugin PluginApi.registerHook type signature with OpenClaw full OpenClawPluginHookOptions (name, description, register). Fixes typecheck error from the 3-arg registerHook call added in #83.

All quality checks pass:
- typecheck (openclaw + service)
- lint (openclaw + service)  
- build (openclaw)
- tests 26/26 (openclaw)