### PR TITLE
fix: prevent watcher menu duplication in TOOLS.md injection

### DIFF
--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -172,7 +172,10 @@ function upsertWatcherSection(toolsMd: string, watcherMenu: string): string {
   const section = `## Watcher\n\n${watcherMenu}\n`;
 
   // If we already injected a Watcher section, replace it.
-  const re = /^## Watcher\n[\s\S]*?(?=^##\s|$)/m;
+  // The `m` flag is needed so `^` matches line starts, but it also makes
+  // `$` match end-of-line instead of end-of-string.  Use a negative
+  // lookahead `$(?![\s\S])` to anchor at true end-of-string.
+  const re = /^## Watcher\n[\s\S]*?(?=\n## |\n# |$(?![\s\S]))/m;
   if (re.test(toolsMd)) {
     return toolsMd.replace(re, section);
   }
@@ -215,6 +218,15 @@ export async function handleAgentBootstrap(
   }
 
   const current = toolsFile.content ?? '';
+
+  // Guard: the bootstrap hook fires on every message turn because OpenClaw
+  // caches bootstrapFiles per session and returns the same mutable objects.
+  // If we already injected the watcher menu into this content, skip to
+  // avoid accumulating duplicate sections.
+  if (current.includes('## Watcher') && current.includes(watcherMenu)) {
+    return;
+  }
+
   const withH1 = ensurePlatformToolsSection(current);
   const updated = upsertWatcherSection(withH1, watcherMenu);
 


### PR DESCRIPTION
## Problem

The watcher menu accumulated N copies in the system prompt (one per message turn in a session), bloating TOOLS.md content by ~4x per session.

## Root Cause

Two compounding bugs:

1. **Regex bug in upsertWatcherSection:** The regex used lazy matching with dollar-sign under the m flag. Since dollar matches end-of-line (not end-of-string) with m, the lazy quantifier captured almost nothing, leaving old watcher content intact during replacement.

2. **No idempotency guard:** OpenClaw calls the bootstrap hook on every message turn (not just session creation), returning the same mutable cached objects. Each hook invocation appended another copy via the broken regex path.

## Fix

- Replace the section-matching regex to use a negative lookahead that anchors at true end-of-string
- Add early-return guard when the current content already contains the exact watcher menu text

## Testing

- All 26 openclaw package tests pass
- TypeScript compilation clean