### PR TITLE
feat(openclaw): strengthen escalation rule with search-first guidance

### DIFF
--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -110,6 +110,7 @@ export async function generateWatcherMenu(apiUrl: string): Promise<string> {
   const lines: string[] = [
     `This environment includes a semantic search index (\`watcher_search\`) covering ${pointCount.toLocaleString()} document chunks.`,
     '**Escalation Rule:** Use `memory_search` for personal operational notes, decisions, and rules. Escalate to `watcher_search` when memory is thin, or when searching the broader archive (tickets, docs, code). ALWAYS use `watcher_search` BEFORE filesystem commands (exec, grep) when looking for information that matches the indexed categories below.',
+    '**Search-first rule:** When a task involves finding, reading, or modifying files in indexed paths, run `watcher_search` FIRST — even if you already know the file path. Search surfaces related files you may not have considered and catches stale artifacts. Direct filesystem access is for acting on search results, not bypassing them.',
     '',
     '### Score Interpretation:',
     '* **Strong:** >= 0.75',


### PR DESCRIPTION
Adds a **search-first rule** to the injected TOOLS.md watcher section: