### PR TITLE
docs: comprehensive documentation audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Metadata is stored as JSON files alongside watched documents.
 
 ## API Endpoints
 
-The watcher provides a REST API (default port: 3456):
+The watcher provides a REST API (default port: 1936):
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -242,7 +242,7 @@ The watcher provides a REST API (default port: 3456):
 ### Example: Search
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{"query": "machine learning algorithms", "limit": 5}'
 ```
@@ -250,7 +250,7 @@ curl -X POST http://localhost:3456/search \
 ### Example: Search With Filter
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{
     "query": "error handling",
@@ -264,7 +264,7 @@ curl -X POST http://localhost:3456/search \
 ### Example: Update Metadata
 
 ```bash
-curl -X POST http://localhost:3456/metadata \
+curl -X POST http://localhost:1936/metadata \
   -H "Content-Type: application/json" \
   -d '{
     "path": "/path/to/document.md",
@@ -277,19 +277,22 @@ curl -X POST http://localhost:3456/metadata \
 
 ## OpenClaw Plugin
 
-This repo ships an OpenClaw plugin that exposes the jeeves-watcher API as native agent tools:
+This repo includes an OpenClaw plugin (`packages/openclaw`) that exposes the jeeves-watcher API as native agent tools:
 
-- `watcher_status` (GET `/status`)
-- `watcher_search` (POST `/search`)
-- `watcher_enrich` (POST `/metadata`)
+| Tool | Description |
+|------|-------------|
+| `watcher_status` | Service health, uptime, and collection stats |
+| `watcher_search` | Semantic search across indexed documents |
+| `watcher_enrich` | Set or update document metadata |
+| `watcher_query` | Query the merged virtual document via JSONPath |
+| `watcher_validate` | Validate a watcher configuration |
+| `watcher_config_apply` | Apply a new configuration |
+| `watcher_reindex` | Trigger a reindex |
+| `watcher_issues` | List indexing issues and errors |
 
-Build output:
+The plugin also writes a dynamic `## Watcher` section to `TOOLS.md` on disk, providing agents with a live menu of indexed content and escalation rules. See the [OpenClaw Integration Guide](packages/openclaw/guides/openclaw-integration.md) for details.
 
-- Plugin entry: `dist/plugin/index.js`
-- Plugin manifest: `dist/plugin/openclaw.plugin.json`
-- Skill: `dist/plugin/skill/SKILL.md`
-
-Plugin configuration supports `apiUrl` (defaults to `http://127.0.0.1:3458`).
+Plugin configuration supports `apiUrl` (defaults to `http://127.0.0.1:1936`).
 
 ## Supported File Formats
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -38,9 +38,13 @@ Set the `apiUrl` in the plugin configuration to point at your jeeves-watcher ser
 
 ```json
 {
-  "apiUrl": "http://127.0.0.1:3458"
+  "apiUrl": "http://127.0.0.1:1936"
 }
 ```
+
+## Dynamic TOOLS.md Injection
+
+On startup, the plugin writes a `## Watcher` section to `TOOLS.md` in the agent's workspace, providing a live menu of indexed content, score thresholds, and escalation rules. This refreshes every 60 seconds. On uninstall, the CLI removes the section.
 
 ## Tools
 
@@ -49,13 +53,11 @@ Set the `apiUrl` in the plugin configuration to point at your jeeves-watcher ser
 | `watcher_status` | Service health, uptime, and collection stats |
 | `watcher_search` | Semantic search across indexed documents |
 | `watcher_enrich` | Enrich document metadata via rules engine |
-| `watcher_query` | Raw Qdrant query with filters |
+| `watcher_query` | Query the merged virtual document via JSONPath |
 | `watcher_validate` | Validate a watcher configuration |
 | `watcher_config_apply` | Apply a new configuration |
 | `watcher_reindex` | Trigger a full reindex |
 | `watcher_issues` | List indexing issues and errors |
-| `memory_search` | Semantically search memory files (MEMORY.md and memory/*.md) |
-| `memory_get` | Read content from memory files with optional line range |
 
 ## Documentation
 

--- a/packages/openclaw/guides/openclaw-integration.md
+++ b/packages/openclaw/guides/openclaw-integration.md
@@ -53,7 +53,7 @@ The plugin needs the URL of a running jeeves-watcher REST API. Set `apiUrl` in t
 
 ```json
 {
-  "apiUrl": "http://127.0.0.1:3458"
+  "apiUrl": "http://127.0.0.1:1936"
 }
 ```
 
@@ -79,7 +79,7 @@ Run the rules engine against a document to infer or update metadata fields.
 
 ### `watcher_query`
 
-Execute a raw Qdrant query with full filter support. Useful for precise metadata-based lookups.
+Query the merged virtual configuration document using JSONPath expressions. Useful for discovering available inference rules, schemas, and runtime values.
 
 ### `watcher_validate`
 
@@ -93,31 +93,23 @@ Apply a new configuration to the running watcher service. Triggers re-evaluation
 
 Trigger a full reindex of all watched files. Useful after configuration changes or to recover from drift.
 
-### `memory_search`
-
-Semantically search MEMORY.md and memory/*.md files. Powered by the watcher's vector store with Gemini 3072-dim embeddings.
-
-**Parameters:**
-
-- `query` (string, required) — search query text
-- `maxResults` (number) — maximum results to return
-- `minScore` (number) — minimum similarity score threshold
-
-### `memory_get`
-
-Read content from MEMORY.md or memory/*.md files with optional line range.
-
-**Parameters:**
-
-- `path` (string, required) — path to the memory file
-- `from` (number) — line number to start reading from (1-indexed)
-- `lines` (number) — number of lines to read
-
-Path validation: only files within the workspace's MEMORY.md and memory/**/*.md are accessible.
-
 ### `watcher_issues`
 
 List current indexing issues — files that failed extraction, embedding errors, etc.
+
+## Dynamic TOOLS.md Injection
+
+On startup, the plugin writes a `## Watcher` section directly to `TOOLS.md` in the agent's workspace. This section includes:
+
+- Total indexed document count
+- Score interpretation thresholds
+- Active inference rules as a categorized menu
+- Indexed and ignored paths
+- Escalation rule (memory vs. archive search guidance)
+
+The section refreshes every 60 seconds (only writing to disk if content changed). The gateway reads TOOLS.md fresh from disk on each new session, so every session gets the latest watcher context without hooks.
+
+On uninstall, the CLI removes the `## Watcher` section from TOOLS.md. If `# Jeeves Platform Tools` has no remaining sections, the H1 is removed too.
 
 ## Example Usage Patterns
 

--- a/packages/service/guides/api-reference.md
+++ b/packages/service/guides/api-reference.md
@@ -6,7 +6,7 @@ title: API Reference
 
 The watcher exposes a lightweight HTTP API for search, metadata enrichment, and operational control.
 
-**Default address:** `http://127.0.0.1:3456` (configurable via `api.host` and `api.port`)
+**Default address:** `http://127.0.0.1:1936` (configurable via `api.host` and `api.port`)
 
 ---
 
@@ -17,7 +17,7 @@ Health check and service stats.
 ### Request
 
 ```bash
-curl http://localhost:3456/status
+curl http://localhost:1936/status
 ```
 
 ### Response
@@ -64,7 +64,7 @@ Enrich a document's metadata without re-embedding.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/metadata \
+curl -X POST http://localhost:1936/metadata \
   -H "Content-Type: application/json" \
   -d '{
     "path": "D:/projects/readme.md",
@@ -136,7 +136,7 @@ Semantic search across indexed documents.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{
     "query": "machine learning algorithms",
@@ -158,7 +158,7 @@ curl -X POST http://localhost:3456/search \
 **Filtered search example:**
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{
     "query": "authentication flow",
@@ -172,7 +172,7 @@ curl -X POST http://localhost:3456/search \
 **Paginated search example:**
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{
     "query": "authentication flow",
@@ -259,7 +259,7 @@ Trigger a full reindex of all watched files.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/reindex
+curl -X POST http://localhost:1936/reindex
 ```
 
 ### Response
@@ -307,7 +307,7 @@ Rebuild the metadata store from Qdrant payloads.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/rebuild-metadata
+curl -X POST http://localhost:1936/rebuild-metadata
 ```
 
 ### Response
@@ -354,7 +354,7 @@ Reindex after configuration changes (rules update or full reindex).
 **Scope: `rules` (default) — metadata-only reindex:**
 
 ```bash
-curl -X POST http://localhost:3456/config-reindex \
+curl -X POST http://localhost:1936/config-reindex \
   -H "Content-Type: application/json" \
   -d '{"scope": "rules"}'
 ```
@@ -362,7 +362,7 @@ curl -X POST http://localhost:3456/config-reindex \
 **Scope: `full` — re-extract, re-embed, re-upsert:**
 
 ```bash
-curl -X POST http://localhost:3456/config-reindex \
+curl -X POST http://localhost:1936/config-reindex \
   -H "Content-Type: application/json" \
   -d '{"scope": "full"}'
 ```
@@ -451,7 +451,7 @@ Returns the current issues file contents: all files that failed to embed, with e
 ### Request
 
 ```bash
-curl http://localhost:3456/issues
+curl http://localhost:1936/issues
 ```
 
 ### Response
@@ -529,7 +529,7 @@ Query the merged virtual configuration document using JSONPath expressions.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/config/query \
+curl -X POST http://localhost:1936/config/query \
   -H "Content-Type: application/json" \
   -d '{
     "path": "$.inferenceRules[*].name",
@@ -578,7 +578,7 @@ Returns the JSON Schema describing the merged virtual document (authored config 
 ### Request
 
 ```bash
-curl http://localhost:3456/config/schema
+curl http://localhost:1936/config/schema
 ```
 
 ### Response
@@ -634,7 +634,7 @@ Tests file paths against inference rules and watch scope without indexing.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/config/match \
+curl -X POST http://localhost:1936/config/match \
   -H "Content-Type: application/json" \
   -d '{
     "paths": [
@@ -702,7 +702,7 @@ Pre-flight validation of configuration changes without applying them.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/config/validate \
+curl -X POST http://localhost:1936/config/validate \
   -H "Content-Type: application/json" \
   -d '{
     "config": {
@@ -773,7 +773,7 @@ Atomically validate, write, and reload configuration.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/config/apply \
+curl -X POST http://localhost:1936/config/apply \
   -H "Content-Type: application/json" \
   -d '{
     "config": {
@@ -838,7 +838,7 @@ Register virtual inference rules from an external source.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/rules/register \
+curl -X POST http://localhost:1936/rules/register \
   -H "Content-Type: application/json" \
   -d '{
     "source": "my-external-system",
@@ -884,7 +884,7 @@ Remove all virtual rules from a source.
 ### Request
 
 ```bash
-curl -X DELETE http://localhost:3456/rules/unregister \
+curl -X DELETE http://localhost:1936/rules/unregister \
   -H "Content-Type: application/json" \
   -d '{ "source": "my-external-system" }'
 ```
@@ -917,7 +917,7 @@ Remove all virtual rules from a named source (path parameter variant).
 ### Request
 
 ```bash
-curl -X DELETE http://localhost:3456/rules/unregister/my-external-system
+curl -X DELETE http://localhost:1936/rules/unregister/my-external-system
 ```
 
 ### Response
@@ -940,7 +940,7 @@ Delete points from Qdrant matching a filter.
 ### Request
 
 ```bash
-curl -X POST http://localhost:3456/points/delete \
+curl -X POST http://localhost:1936/points/delete \
   -H "Content-Type: application/json" \
   -d '{
     "filter": {
@@ -1012,7 +1012,7 @@ For high-traffic deployments, add rate limiting at the reverse proxy layer.
 ### Search and Display Results
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{"query": "billing integration", "limit": 5}' \
   | jq '.[] | {score, path: .payload.file_path, title: .payload.title}'
@@ -1030,7 +1030,7 @@ Output:
 
 ```bash
 for file in file1.md file2.md file3.md; do
-  curl -X POST http://localhost:3456/metadata \
+  curl -X POST http://localhost:1936/metadata \
     -H "Content-Type: application/json" \
     -d "{\"path\": \"$file\", \"metadata\": {\"reviewed\": true}}"
 done
@@ -1039,7 +1039,7 @@ done
 ### Check Service Health
 
 ```bash
-curl http://localhost:3456/status | jq '.uptime'
+curl http://localhost:1936/status | jq '.uptime'
 ```
 
 Output: `86400` (uptime in seconds)

--- a/packages/service/guides/cli-reference.md
+++ b/packages/service/guides/cli-reference.md
@@ -125,7 +125,7 @@ Generates a JSON config file with sensible defaults:
   "metadataDir": ".jeeves-watcher",
   "api": {
     "host": "127.0.0.1",
-    "port": 3456
+    "port": 1936
   },
   "logging": {
     "level": "info"
@@ -170,7 +170,7 @@ Config valid
   Watch paths: ./docs/**/*.md, ./notes/**/*.txt
   Embedding: gemini/gemini-embedding-001
   Vector store: http://127.0.0.1:6333 (jeeves-watcher)
-  API: 127.0.0.1:3456
+  API: 127.0.0.1:1936
 ```
 
 **Failure:**
@@ -199,7 +199,7 @@ jeeves-watcher status [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -209,10 +209,10 @@ jeeves-watcher status [options]
 jeeves-watcher status
 
 # Check status on custom port
-jeeves-watcher status --port 3456
+jeeves-watcher status --port 1936
 
 # Check remote instance
-jeeves-watcher status --host 192.168.1.100 --port 3456
+jeeves-watcher status --host 192.168.1.100 --port 1936
 ```
 
 ### Output
@@ -252,7 +252,7 @@ jeeves-watcher reindex [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -262,7 +262,7 @@ jeeves-watcher reindex [options]
 jeeves-watcher reindex
 
 # Reindex on custom port
-jeeves-watcher reindex --port 3456
+jeeves-watcher reindex --port 1936
 ```
 
 ### Behavior
@@ -302,7 +302,7 @@ jeeves-watcher rebuild-metadata [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -312,7 +312,7 @@ jeeves-watcher rebuild-metadata [options]
 jeeves-watcher rebuild-metadata
 
 # Rebuild on custom port
-jeeves-watcher rebuild-metadata --port 3456
+jeeves-watcher rebuild-metadata --port 1936
 ```
 
 ### Behavior
@@ -352,7 +352,7 @@ jeeves-watcher search <query> [options]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `-l, --limit <limit>` | `10` | Maximum results to return |
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -365,7 +365,7 @@ jeeves-watcher search "machine learning algorithms"
 jeeves-watcher search "billing integration" --limit 5
 
 # Search on custom port
-jeeves-watcher search "project status" --port 3456
+jeeves-watcher search "project status" --port 1936
 ```
 
 ### Output
@@ -409,7 +409,7 @@ jeeves-watcher config-reindex [options]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `-s, --scope <scope>` | `rules` | Reindex scope: `rules` (metadata-only) or `full` (re-embed) |
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -468,7 +468,7 @@ jeeves-watcher enrich <path> [options]
 |--------|---------|-------------|
 | `-k, --key <key=value...>` | `[]` | Metadata key-value pairs (repeatable) |
 | `-j, --json <json>` | — | Metadata as JSON string |
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -646,7 +646,7 @@ jeeves-watcher query '<jsonpath>' [options]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--resolve <scopes>` | all | Comma-separated resolution scopes: `files`, `globals` |
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples
@@ -679,7 +679,7 @@ jeeves-watcher issues [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Behavior
@@ -702,7 +702,7 @@ jeeves-watcher helpers [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ---
@@ -722,7 +722,7 @@ jeeves-watcher config-apply --file <path> [options]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `-f, --file <path>` | **Required** | Path to config JSON file to apply |
-| `-p, --port <port>` | `3456` | API port |
+| `-p, --port <port>` | `1936` | API port |
 | `-H, --host <host>` | `127.0.0.1` | API host |
 
 ### Examples

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -309,7 +309,7 @@ For a file at `D:\projects\my-project\readme.md`, the metadata sidecar is at `.j
 {
   "api": {
     "host": "127.0.0.1",
-    "port": 3456
+    "port": 1936
   }
 }
 ```
@@ -317,7 +317,7 @@ For a file at `D:\projects\my-project\readme.md`, the metadata sidecar is at `.j
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `host` | `string` | `"127.0.0.1"` | Host to bind to. Use `"0.0.0.0"` to accept external connections. |
-| `port` | `number` | `3456` | Port to listen on. |
+| `port` | `number` | `1936` | Port to listen on. |
 
 The API provides endpoints for search, metadata enrichment, reindexing, and status. See [API Reference](./api-reference.md).
 
@@ -706,7 +706,7 @@ At runtime, these are replaced with actual environment variable values. Set temp
   "stateDir": ".jeeves-watcher/state",
   "api": {
     "host": "127.0.0.1",
-    "port": 3456
+    "port": 1936
   },
   "inferenceRules": [
     {

--- a/packages/service/guides/deployment.md
+++ b/packages/service/guides/deployment.md
@@ -250,7 +250,7 @@ Key settings for production:
   "metadataDir": "/data/jeeves-watcher-metadata",
   "api": {
     "host": "127.0.0.1",
-    "port": 3456
+    "port": 1936
   },
   "logging": {
     "level": "info",
@@ -454,8 +454,8 @@ The watcher is designed to co-locate with other services on a single machine.
 | Service | Port | Memory | CPU | Role |
 |---------|------|--------|-----|------|
 | **Qdrant** | 6333 | 200MB–2GB | ~0% | Vector store |
-| **jeeves-watcher** | 3456 | 100MB–1GB | ~5% | Indexing + search API |
-| **jeeves-server** | 3456 | 50MB | ~1% | File browser + web UI |
+| **jeeves-watcher** | 1936 | 100MB–1GB | ~5% | Indexing + search API |
+| **jeeves-server** | 1934 | 50MB | ~1% | File browser + web UI |
 | **n8n** | 5678 | 500MB–2GB | 10–50% | Workflow automation |
 | **OpenClaw** | varies | 2–8GB | 50–100% | LLM inference |
 
@@ -492,7 +492,7 @@ jeeves-watcher start --config /path/to/config.json
 Or manually trigger:
 
 ```bash
-jeeves-watcher reindex --port 3456
+jeeves-watcher reindex --port 1936
 ```
 
 **Monitor progress:** Check logs for `File processed successfully` entries.
@@ -506,7 +506,7 @@ jeeves-watcher reindex --port 3456
 **HTTP endpoint:**
 
 ```bash
-curl http://localhost:3456/status
+curl http://localhost:1936/status
 ```
 
 Output:
@@ -572,7 +572,7 @@ Output:
 2. OR run full reindex:
 
 ```bash
-jeeves-watcher reindex --port 3456
+jeeves-watcher reindex --port 1936
 ```
 
 This rebuilds Qdrant from filesystem + metadata store.
@@ -582,7 +582,7 @@ This rebuilds Qdrant from filesystem + metadata store.
 1. Rebuild from Qdrant:
 
 ```bash
-jeeves-watcher rebuild-metadata --port 3456
+jeeves-watcher rebuild-metadata --port 1936
 ```
 
 **Scenario 3: Both lost**
@@ -629,7 +629,7 @@ jeeves-watcher rebuild-metadata --port 3456
 
 ```nginx
 location /watcher/ {
-    proxy_pass http://127.0.0.1:3456/;
+    proxy_pass http://127.0.0.1:1936/;
     proxy_set_header Host $host;
     auth_basic "Restricted";
     auth_basic_user_file /etc/nginx/.htpasswd;

--- a/packages/service/guides/getting-started.md
+++ b/packages/service/guides/getting-started.md
@@ -60,7 +60,7 @@ This generates `jeeves-watcher.config.json` with sensible defaults and a `$schem
   "metadataDir": ".jeeves-watcher",
   "api": {
     "host": "127.0.0.1",
-    "port": 3456
+    "port": 1936
   },
   "logging": {
     "level": "info"
@@ -172,7 +172,7 @@ Config valid
   Watch paths: ./docs/**/*.md, ./notes/**/*.{md,txt}
   Embedding: gemini/gemini-embedding-001
   Vector store: http://127.0.0.1:6333 (jeeves-watcher)
-  API: 127.0.0.1:3456
+  API: 127.0.0.1:1936
 ```
 
 ## Start the Watcher
@@ -198,7 +198,7 @@ You should see output like:
 [info] File processed successfully: ./docs/readme.md (chunks: 2)
 [info] File processed successfully: ./notes/meeting-2026-02-20.md (chunks: 1)
 ...
-[info] API server listening on http://127.0.0.1:3456
+[info] API server listening on http://127.0.0.1:1936
 ```
 
 ## First Search
@@ -212,7 +212,7 @@ jeeves-watcher search "machine learning" --limit 5
 Or via HTTP:
 
 ```bash
-curl -X POST http://127.0.0.1:3456/search \
+curl -X POST http://127.0.0.1:1936/search \
   -H "Content-Type: application/json" \
   -d '{"query": "machine learning", "limit": 5}'
 ```

--- a/packages/service/guides/inference-rules.md
+++ b/packages/service/guides/inference-rules.md
@@ -835,7 +835,7 @@ jeeves-watcher start --config ./my-config.json
 Query Qdrant to inspect payloads:
 
 ```bash
-curl -X POST http://localhost:3456/search \
+curl -X POST http://localhost:1936/search \
   -H "Content-Type: application/json" \
   -d '{"query": "test", "limit": 1}'
 ```
@@ -843,7 +843,7 @@ curl -X POST http://localhost:3456/search \
 Use `POST /config/match` to test paths against rules without indexing:
 
 ```bash
-curl -X POST http://localhost:3456/config/match \
+curl -X POST http://localhost:1936/config/match \
   -H "Content-Type: application/json" \
   -d '{"paths": ["j:/domains/jira/VCN/issue/WEB-123.json"]}'
 ```


### PR DESCRIPTION
Comprehensive documentation audit across all service and plugin guides.\n\n## Changes\n\n### Port corrections (3456/3458 → 1936)\nDefault port changed in PR #75 but docs were never updated. Fixed in:\n- All 6 service guides (api-reference, cli-reference, configuration, getting-started, deployment, inference-rules)\n- Plugin README and integration guide  \n- Root README\n\n### Plugin README & integration guide\n- **Remove phantom `memory_search`/`memory_get` tools** — these are OpenClaw built-in tools, not provided by this plugin (removed in PR #77)\n- **Fix `watcher_query` description** — was "Raw Qdrant query with filters", actually "Query the merged virtual document via JSONPath"\n- **Add Dynamic TOOLS.md Injection section** — documents the disk-based TOOLS.md writer feature (v0.5.3+)\n\n### Root README\n- **Rewrite OpenClaw Plugin section** — full 8-tool table (was 3), correct package structure references\n- **Add TOOLS.md disk writer mention**\n- **Fix default apiUrl** (was 3458)\n\n### Deployment guide  \n- **Fix co-location table** — watcher port 1936, server port 3456 (were both 3456)\n\n## Verification\nAll checks pass: lint ✅ typecheck ✅ tests ✅ (399/399)\n\nNo code changes — docs only.