### PR TITLE
feature: add proactive bootstrap diagnostics to prompt injection

### DIFF
--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -103,8 +103,31 @@ export async function generateWatcherMenu(apiUrl: string): Promise<string> {
         if (typeof p === 'string') ignoredPaths.push(p);
       }
     }
-  } catch {
-    return '*Watcher service is currently unreachable.*';
+  } catch (err) {
+    let qdrantStatus = '*Unknown*';
+    try {
+      // Assuming Qdrant runs locally on the default port
+      const res = await fetch('http://127.0.0.1:6333/healthz', { signal: AbortSignal.timeout(1000) });
+      qdrantStatus = res.ok ? 'Running' : 'Error';
+    } catch {
+      qdrantStatus = 'Down / Unreachable';
+    }
+
+    return `> **ACTION REQUIRED: Watcher service is unreachable.**
+> The jeeves-watcher service API at ${apiUrl} is down or not installed.
+> **Diagnostic Info:**
+> - Watcher API (${apiUrl}): Unreachable
+> - Qdrant (http://127.0.0.1:6333): ${qdrantStatus}
+>
+> **DO NOT** ignore this. Read the \`jeeves-watcher\` skill's **Bootstrap** section immediately and walk the user through the setup process. Use the diagnostic info above to determine if Qdrant needs installing/starting, or if only the watcher service needs attention.`;
+  }
+
+  if (pointCount === 0) {
+    return `> **ACTION REQUIRED: Watcher service is empty.**
+> The jeeves-watcher service is running at ${apiUrl} but has no indexed data.
+> The service has either just been installed (no configuration/data), or indexing hasn't run.
+>
+> **DO NOT** ignore this. Read the \`jeeves-watcher\` skill's **Bootstrap** section immediately and walk the user through the setup process to configure and reindex the workspace.`;
   }
 
   const lines: string[] = [


### PR DESCRIPTION
Implements proactive diagnostic discovery when the watcher API fails. Instead of returning a static connection failure, the plugin performs an out-of-band fetch to Qdrant (http://127.0.0.1:6333/healthz) and injects specific failure data into the TOOLS.md menu. This ensures the agent has the exact missing dependencies laid out to drive proactive issue resolution.