### PR TITLE
fix: pass valuesManager and issuesManager to config-reindex handler

### DIFF
--- a/packages/service/src/api/handlers/configReindex.test.ts
+++ b/packages/service/src/api/handlers/configReindex.test.ts
@@ -41,6 +41,8 @@ function createDeps() {
     processor: {} as unknown as DocumentProcessor,
     logger: pino({ level: 'silent' }),
     reindexTracker: new ReindexTracker(),
+    valuesManager: { clearAll: vi.fn(), getAll: vi.fn().mockReturnValue({}) },
+    issuesManager: { getAll: vi.fn().mockReturnValue({}) },
   };
 }
 
@@ -84,6 +86,24 @@ describe('createConfigReindexHandler', () => {
     });
     expect(mockedExecuteReindex).toHaveBeenCalledWith(
       expect.objectContaining({ config: deps.config }),
+      'full',
+    );
+  });
+
+  it('passes valuesManager and issuesManager to executeReindex', async () => {
+    const deps = createDeps();
+    const handler = createConfigReindexHandler(deps);
+    const reply = mockReply();
+    await handler(
+      mockRequest({ scope: 'full' }),
+      reply as unknown as FastifyReply,
+    );
+
+    expect(mockedExecuteReindex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        valuesManager: deps.valuesManager,
+        issuesManager: deps.issuesManager,
+      }),
       'full',
     );
   });

--- a/packages/service/src/api/handlers/configReindex.ts
+++ b/packages/service/src/api/handlers/configReindex.ts
@@ -7,7 +7,9 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import type pino from 'pino';
 
 import type { JeevesWatcherConfig } from '../../config/types';
+import type { IssuesManager } from '../../issues';
 import type { DocumentProcessorInterface } from '../../processor';
+import type { ValuesManager } from '../../values';
 import { executeReindex } from '../executeReindex';
 import type { ReindexTracker } from '../ReindexTracker';
 import { wrapHandler } from './wrapHandler';
@@ -17,6 +19,8 @@ export interface ConfigReindexRouteDeps {
   processor: DocumentProcessorInterface;
   logger: pino.Logger;
   reindexTracker: ReindexTracker;
+  valuesManager?: ValuesManager;
+  issuesManager?: IssuesManager;
 }
 
 type ConfigReindexRequest = FastifyRequest<{
@@ -39,6 +43,8 @@ export function createConfigReindexHandler(deps: ConfigReindexRouteDeps) {
           processor: deps.processor,
           logger: deps.logger,
           reindexTracker: deps.reindexTracker,
+          valuesManager: deps.valuesManager,
+          issuesManager: deps.issuesManager,
         },
         scope,
       );

--- a/packages/service/src/api/index.ts
+++ b/packages/service/src/api/index.ts
@@ -181,7 +181,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
 
   app.post(
     '/config-reindex',
-    createConfigReindexHandler({ config, processor, logger, reindexTracker }),
+    createConfigReindexHandler({ config, processor, logger, reindexTracker, valuesManager, issuesManager }),
   );
 
   app.get(


### PR DESCRIPTION
The POST /config-reindex handler was not passing valuesManager or issuesManager to executeReindex, so API-triggered reindexes (including via the OpenClaw watcher_reindex tool) never populated the values index or correctly handled the issues scope.

Changes:
- Add valuesManager and issuesManager to ConfigReindexRouteDeps interface
- Pass both through in the route registration (api/index.ts)
- Add test verifying both are forwarded to executeReindex

This is why values.json was never created after the v0.8.1 fix.