### PR TITLE
fix: update values index before hash check in processFile

### DIFF
--- a/packages/service/src/processor/index.ts
+++ b/packages/service/src/processor/index.ts
@@ -152,6 +152,14 @@ export class DocumentProcessor implements DocumentProcessorInterface {
           metadataWithRules,
         } = await this.buildMetadataWithRules(filePath);
 
+        // Update values index before any skip conditions — values must
+        // reflect current rule matches even when content is unchanged.
+        if (this.valuesManager) {
+          for (const ruleName of matchedRules) {
+            this.valuesManager.update(ruleName, metadata);
+          }
+        }
+
         const textToEmbed = renderedContent ?? extracted.text;
         if (!textToEmbed.trim()) {
           this.logger.debug({ filePath }, 'Skipping empty file');
@@ -191,11 +199,6 @@ export class DocumentProcessor implements DocumentProcessorInterface {
         );
 
         this.issuesManager?.clear(filePath);
-        if (this.valuesManager) {
-          for (const ruleName of matchedRules) {
-            this.valuesManager.update(ruleName, metadata);
-          }
-        }
       },
       undefined,
     );

--- a/packages/service/src/processor/processor.test.ts
+++ b/packages/service/src/processor/processor.test.ts
@@ -153,6 +153,43 @@ describe('DocumentProcessor', () => {
       expect(vectorStore.upsert).not.toHaveBeenCalled();
     });
 
+    it('updates values even when content hash is unchanged', async () => {
+      const {
+        vectorStore,
+        embeddingProvider,
+        valuesManager,
+        config,
+        logger,
+      } = createMocks();
+      mockedBuildMergedMetadata.mockResolvedValue(defaultMergedMetadata());
+
+      // Simulate existing payload with matching hash — embedding skipped
+      const { contentHash } = await import('../hash');
+      const hash = contentHash('hello world');
+      vectorStore.getPayload.mockResolvedValue({
+        content_hash: hash,
+        total_chunks: 1,
+      });
+
+      const processor = new DocumentProcessor({
+        config,
+        embeddingProvider,
+        vectorStore: vectorStore as unknown as VectorStoreClient,
+        compiledRules: [],
+        logger,
+        valuesManager: valuesManager as unknown as ValuesManager,
+      });
+      await processor.processFile('/test.txt');
+
+      // Embedding should be skipped
+      expect(vectorStore.upsert).not.toHaveBeenCalled();
+      // But values should still be updated
+      expect(valuesManager.update).toHaveBeenCalledWith(
+        'rule1',
+        expect.objectContaining({ domain: 'test' }),
+      );
+    });
+
     it('processes successfully: clears issues, updates values', async () => {
       const {
         vectorStore,


### PR DESCRIPTION
Two bugs prevented ValuesManager from ever populating during reindex:

**Bug 1: Processor never had valuesManager.** In \pp/index.ts\, the processor was constructed *before* \ValuesManager\ was created, so \	his.valuesManager\ was always \undefined\ inside the processor. Fixed by moving manager creation before processor construction and passing both to the constructor.

**Bug 2: Values updated too late in processFile.** \aluesManager.update()\ was called *after* the content hash check. During full reindex, \clearAll()\ wipes all values, but most files are skipped (content unchanged), so values were never repopulated. Fixed by moving the update before the hash check.

**Verified against prod:** Dev build installed, full reindex triggered. 23 rules populated with 18K+ distinct values. Facets endpoint returns 21/22 facets with live values. Clean build with no type warnings.

### Commits
1. \ix: update values index before hash check in processFile\ — move valuesManager.update() before skip conditions + new test
2. \ix: pass valuesManager and issuesManager to processor constructor\ — wire managers into processor at construction time
3. \ix: cast mock managers in configReindex test to fix build warnings\ — proper type casts in test mocks