### PR TITLE
fix: skip live value aggregation for non-enumerated facet uiHint types

### DIFF
--- a/packages/service/src/api/handlers/facets.test.ts
+++ b/packages/service/src/api/handlers/facets.test.ts
@@ -247,4 +247,112 @@ describe('GET /search/facets handler', () => {
     expect(result.facets).toHaveLength(1);
     expect(result.facets[0].field).toBe('visible');
   });
+
+  it('skips live value aggregation for non-enumerated uiHint types', () => {
+    const config = makeConfig([
+      {
+        name: 'rule',
+        description: 'R',
+        match: {},
+        schema: [
+          {
+            properties: {
+              title: { type: 'string', uiHint: 'text' },
+              issue_key: { type: 'string', uiHint: 'number' },
+              domain: { type: 'string', uiHint: 'dropdown' },
+            },
+          },
+        ],
+      },
+    ]);
+    const values = makeValuesManager({
+      rule: {
+        title: ['Doc A', 'Doc B', 'Doc C'],
+        issue_key: ['WEB-1', 'WEB-2', 'WEB-3'],
+        domain: ['slack', 'email'],
+      },
+    });
+
+    const handler = createFacetsHandler(
+      makeDeps({ config, valuesManager: values }),
+    );
+    const result = handler();
+
+    const titleFacet = result.facets.find((f) => f.field === 'title');
+    const keyFacet = result.facets.find((f) => f.field === 'issue_key');
+    const domainFacet = result.facets.find((f) => f.field === 'domain');
+
+    // Non-enumerated hints: empty values
+    expect(titleFacet?.values).toEqual([]);
+    expect(keyFacet?.values).toEqual([]);
+    // Enumerated hint: live values populated
+    expect(domainFacet?.values).toEqual(['email', 'slack']);
+  });
+
+  it('still returns enum values even for non-enumerated uiHint types', () => {
+    const config = makeConfig([
+      {
+        name: 'rule',
+        description: 'R',
+        match: {},
+        schema: [
+          {
+            properties: {
+              status: {
+                type: 'string',
+                uiHint: 'text',
+                enum: ['open', 'closed'],
+              },
+            },
+          },
+        ],
+      },
+    ]);
+    const values = makeValuesManager({
+      rule: { status: ['open', 'closed', 'pending'] },
+    });
+
+    const handler = createFacetsHandler(
+      makeDeps({ config, valuesManager: values }),
+    );
+    const result = handler();
+
+    // Explicit enum always wins, regardless of uiHint
+    expect(result.facets[0].values).toEqual(['open', 'closed']);
+  });
+
+  it('aggregates values for tags and multiselect uiHint types', () => {
+    const config = makeConfig([
+      {
+        name: 'rule',
+        description: 'R',
+        match: {},
+        schema: [
+          {
+            properties: {
+              labels: { type: 'string', uiHint: 'tags' },
+              assignees: { type: 'string', uiHint: 'multiselect' },
+            },
+          },
+        ],
+      },
+    ]);
+    const values = makeValuesManager({
+      rule: {
+        labels: ['bug', 'feature'],
+        assignees: ['alice', 'bob'],
+      },
+    });
+
+    const handler = createFacetsHandler(
+      makeDeps({ config, valuesManager: values }),
+    );
+    const result = handler();
+
+    const labelsFacet = result.facets.find((f) => f.field === 'labels');
+    const assigneesFacet = result.facets.find((f) => f.field === 'assignees');
+
+    expect(labelsFacet?.values).toEqual(['bug', 'feature']);
+    expect(assigneesFacet?.values).toEqual(['alice', 'bob']);
+  });
 });

--- a/packages/service/src/api/handlers/facets.ts
+++ b/packages/service/src/api/handlers/facets.ts
@@ -72,6 +72,18 @@ function isFacetable(prop: ResolvedProperty): boolean {
   return prop.uiHint !== undefined || prop.enum !== undefined;
 }
 
+/** uiHint types that represent enumerated value selection. */
+const ENUMERATED_HINTS = new Set(['dropdown', 'tags', 'select', 'multiselect']);
+
+/**
+ * Check whether a uiHint type supports value enumeration.
+ * Non-enumerated hints (text, number, date, range, etc.) should not
+ * aggregate live values — the client uses free-form input instead.
+ */
+function isEnumeratedHint(uiHint: string): boolean {
+  return ENUMERATED_HINTS.has(uiHint);
+}
+
 /**
  * Build the schema-derived facet structure from inference rules.
  *
@@ -147,20 +159,29 @@ export function createFacetsHandler(deps: FacetsHandlerDeps) {
     const facets: Facet[] = [];
 
     for (const [field, schema] of cached.fields) {
-      // Collect live values from all rules that define this field
-      const liveValues = new Set<unknown>();
-      for (const ruleName of schema.rules) {
-        const fieldValues = allValues[ruleName]?.[field];
-        if (fieldValues) {
-          for (const v of fieldValues) liveValues.add(v);
+      // Only aggregate live values for enumerated hint types (dropdown, tags, etc.)
+      // Non-enumerated types (text, number, date, range) use free-form input.
+      let values: unknown[];
+      if (schema.enumValues) {
+        values = schema.enumValues;
+      } else if (isEnumeratedHint(schema.uiHint)) {
+        const liveValues = new Set<unknown>();
+        for (const ruleName of schema.rules) {
+          const fieldValues = allValues[ruleName]?.[field];
+          if (fieldValues) {
+            for (const v of fieldValues) liveValues.add(v);
+          }
         }
+        values = [...liveValues].sort();
+      } else {
+        values = [];
       }
 
       facets.push({
         field,
         type: schema.type,
         uiHint: schema.uiHint,
-        values: schema.enumValues ?? [...liveValues].sort(),
+        values,
         rules: schema.rules,
       });
     }


### PR DESCRIPTION
## Problem

The `/search/facets` endpoint aggregates distinct values from `ValuesManager` for **all** facets, including those with `uiHint: "text"` or `"number"`. For high-cardinality fields like `issue_key` or `title`, this means thousands of values serialized, transferred, and parsed — all ignored by the client.

## Fix

Only enumerated `uiHint` types (`dropdown`, `tags`, `select`, `multiselect`) aggregate live values. Non-enumerated types (`text`, `number`, `date`, `range`, etc.) return an empty `values` array.

**Explicit `enum` declarations still take precedence** regardless of `uiHint` — so a field with `uiHint: "text"` but explicit `enum: ["a", "b"]` still returns those values.

## Changes

- `facets.ts`: Added `isEnumeratedHint()` helper and `ENUMERATED_HINTS` set. Restructured value resolution to skip aggregation for non-enumerated hints.
- `facets.test.ts`: Added 3 tests (non-enumerated skip, enum override on non-enumerated hint, tags/multiselect aggregation).

## Verification

- typecheck ✅
- lint ✅
- build ✅
- 451 service tests pass (62 files)
- Facets tests: 10 pass (was 7, +3 new)
