### PR TITLE
perf: replace LangChain Gemini wrapper with direct API (13s → ~1s search)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -327,8 +328,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@commander-js/extra-typings": {
       "version": "14.0.0",
@@ -1211,15 +1211,6 @@
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1728,7 +1719,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.28.tgz",
       "integrity": "sha512-6FAGdezEp8zHY92LtnsAiv54KaG41nBdsuukk+R+1484edV20cVOyIc36ANuGKPx0pmYFCBWhCUdO0jxB/zn2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -1746,65 +1736,6 @@
       }
     },
     "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/google-genai": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-2.1.20.tgz",
-      "integrity": "sha512-x4zS3iv6x27M38izV/einJM9qXAGvVAYt2fUW8hiQnh9AX0vYVJBkoqGpxsvHNejqGYlTXOollPUp3XuVjlHjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@google/generative-ai": "^0.24.0",
-        "uuid": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.1.27"
-      }
-    },
-    "node_modules/@langchain/google-genai/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/qdrant": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@langchain/qdrant/-/qdrant-1.0.1.tgz",
-      "integrity": "sha512-y3QK+KXgA++ZXAE9ofKjT5u6yh4FQqTF5CpdWIynKV2Zz926SSFq3ELbPhvMfUGu61Ils7p6jd1DIbXpZNAkgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@qdrant/js-client-rest": "^1.15.0",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.0.0"
-      }
-    },
-    "node_modules/@langchain/qdrant/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
@@ -1899,6 +1830,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1999,6 +1931,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2155,6 +2088,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3194,6 +3128,7 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3339,6 +3274,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3743,6 +3679,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3844,7 +3781,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4139,7 +4075,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4444,7 +4379,6 @@
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
       "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "simple-wcswidth": "^1.1.2"
       }
@@ -4626,7 +4560,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4996,6 +4929,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5056,6 +4990,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6725,6 +6660,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -6907,7 +6843,6 @@
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.6.tgz",
       "integrity": "sha512-T/RA2l2MsTYX0z1aW8rQ2hBQZEOuXV2v/6tkfG6R5EotJTKMpw1dERCbvP8ezOP8otyWfnNlQA88ZnMRsQ7CHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "chalk": "^5.6.2",
@@ -6942,7 +6877,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6959,7 +6893,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7839,7 +7772,6 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -8182,7 +8114,6 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8224,7 +8155,6 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -8241,7 +8171,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -8620,6 +8549,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8783,6 +8713,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9220,6 +9151,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9475,8 +9407,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -9880,6 +9811,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9926,6 +9858,7 @@
       "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -9985,6 +9918,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10296,6 +10230,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10371,6 +10306,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -10927,7 +10863,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-watcher-openclaw",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-watcher-openclaw": "dist/cli.js"
@@ -10949,13 +10885,11 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-watcher",
-      "version": "0.8.5",
+      "version": "0.9.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@karmaniverous/jsonmap": "^2.1.1",
-        "@langchain/google-genai": "*",
-        "@langchain/qdrant": "*",
         "@langchain/textsplitters": "*",
         "@qdrant/js-client-rest": "*",
         "ajv": "^8.18.0",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -52,8 +52,6 @@
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
     "@karmaniverous/jsonmap": "^2.1.1",
-    "@langchain/google-genai": "*",
-    "@langchain/qdrant": "*",
     "@langchain/textsplitters": "*",
     "@qdrant/js-client-rest": "*",
     "ajv": "^8.18.0",

--- a/packages/service/src/embedding/geminiProvider.ts
+++ b/packages/service/src/embedding/geminiProvider.ts
@@ -1,9 +1,8 @@
 /**
  * @module embedding/geminiProvider
- * Gemini embedding provider using Google Generative AI.
+ * Gemini embedding provider using the Google Generative AI REST API directly.
  */
 
-import { GoogleGenerativeAIEmbeddings } from '@langchain/google-genai';
 import type pino from 'pino';
 
 import type { EmbeddingConfig } from '../config/types';
@@ -12,8 +11,21 @@ import { normalizeError } from '../util/normalizeError';
 import { retry } from '../util/retry';
 import type { EmbeddingProvider } from './types';
 
+/** Shape of a single embedding request within a batch. */
+interface EmbedRequest {
+  model: string;
+  content: { parts: Array<{ text: string }> };
+}
+
+/** Shape of the batchEmbedContents API response. */
+interface BatchEmbedResponse {
+  embeddings: Array<{ values: number[] }>;
+}
+
+const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
 /**
- * Create a Gemini embedding provider using the Google Generative AI SDK.
+ * Create a Gemini embedding provider using the Google Generative AI REST API.
  *
  * @param config - The embedding configuration.
  * @param logger - Optional pino logger for retry warnings.
@@ -31,11 +43,11 @@ export function createGeminiProvider(
   }
 
   const dimensions = config.dimensions ?? 3072;
+  const model = config.model;
+  const apiKey = config.apiKey;
   const log = getLogger(logger);
-  const embedder = new GoogleGenerativeAIEmbeddings({
-    apiKey: config.apiKey,
-    model: config.model,
-  });
+
+  const url = `${GEMINI_API_BASE}/models/${model}:batchEmbedContents?key=${apiKey}`;
 
   return {
     dimensions,
@@ -44,13 +56,31 @@ export function createGeminiProvider(
         async (attempt) => {
           if (attempt > 1) {
             log.warn(
-              { attempt, provider: 'gemini', model: config.model },
+              { attempt, provider: 'gemini', model },
               'Retrying embedding request',
             );
           }
 
-          // embedDocuments returns vectors for multiple texts
-          return embedder.embedDocuments(texts);
+          const requests: EmbedRequest[] = texts.map((text) => ({
+            model: `models/${model}`,
+            content: { parts: [{ text }] },
+          }));
+
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ requests }),
+          });
+
+          if (!response.ok) {
+            const body = await response.text();
+            throw new Error(
+              `Gemini API error ${String(response.status)}: ${body}`,
+            );
+          }
+
+          const data = (await response.json()) as BatchEmbedResponse;
+          return data.embeddings.map((e) => e.values);
         },
         {
           attempts: 5,
@@ -63,7 +93,7 @@ export function createGeminiProvider(
                 attempt,
                 delayMs,
                 provider: 'gemini',
-                model: config.model,
+                model,
                 err: normalizeError(error),
               },
               'Embedding call failed; will retry',


### PR DESCRIPTION
## Problem

Every search query takes ~13 seconds due to the LangChain `@langchain/google-genai` wrapper. The same Gemini embedding call via direct REST API takes ~500ms — a 26x overhead.

## Fix

Replace `GoogleGenerativeAIEmbeddings.embedDocuments()` with a direct `fetch()` to `generativelanguage.googleapis.com/v1beta/models/{model}:batchEmbedContents`. Same API, same results, no wrapper overhead.

Also remove unused `@langchain/qdrant` dependency (not imported anywhere).

**Remaining LangChain dep:** `@langchain/textsplitters` — actively used for markdown-aware text chunking. Kept intentionally.

## Changes

- `geminiProvider.ts`: Replaced LangChain wrapper with direct Gemini REST API calls using `batchEmbedContents` endpoint
- `package.json`: Removed `@langchain/google-genai` and `@langchain/qdrant` dependencies
- `package-lock.json`: Updated

## Expected Impact

Search latency: ~13s → ~1s (embedding + Qdrant query)

## Verification

- typecheck ✅
- lint ✅
- build ✅
- 451 service tests pass (62 files)
- knip ✅
