### PR TITLE
perf: use node:https with keep-alive for Gemini embedding (13s → 2-4s)

### DIFF
--- a/packages/service/src/embedding/geminiProvider.ts
+++ b/packages/service/src/embedding/geminiProvider.ts
@@ -1,7 +1,11 @@
 /**
  * @module embedding/geminiProvider
  * Gemini embedding provider using the Google Generative AI REST API directly.
+ * Uses node:https with a keep-alive agent for reliable performance in
+ * long-running processes (avoids undici/fetch event-loop contention).
  */
+
+import https from 'node:https';
 
 import type pino from 'pino';
 
@@ -23,6 +27,44 @@ interface BatchEmbedResponse {
 }
 
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+/** Persistent HTTPS agent for connection reuse. */
+const agent = new https.Agent({ keepAlive: true });
+
+/** Make an HTTPS POST request using node:https (bypasses undici/fetch). */
+function httpsPost(
+  url: string,
+  body: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = https.request(
+      {
+        hostname: parsed.hostname,
+        path: parsed.pathname + parsed.search,
+        method: 'POST',
+        agent,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
 
 /**
  * Create a Gemini embedding provider using the Google Generative AI REST API.
@@ -66,20 +108,15 @@ export function createGeminiProvider(
             content: { parts: [{ text }] },
           }));
 
-          const response = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ requests }),
-          });
+          const response = await httpsPost(url, JSON.stringify({ requests }));
 
-          if (!response.ok) {
-            const body = await response.text();
+          if (response.status < 200 || response.status >= 300) {
             throw new Error(
-              `Gemini API error ${String(response.status)}: ${body}`,
+              `Gemini API error ${String(response.status)}: ${response.body}`,
             );
           }
 
-          const data = (await response.json()) as BatchEmbedResponse;
+          const data = JSON.parse(response.body) as BatchEmbedResponse;
           return data.embeddings.map((e) => e.values);
         },
         {


### PR DESCRIPTION
Replaces undici \etch()\ with \
ode:https\ + persistent keep-alive agent for the Gemini embedding call. \etch()\ exhibits ~13s latency in the watcher's long-running process due to event-loop contention. \
ode:https\ avoids this.\n\n**Benchmarks (150k points):**\n- fetch() in-process: ~13-18s\n- node:https keep-alive: ~2-4s steady-state\n- Raw API standalone: ~400ms\n\n**Verification:** tsc ✅ | lint ✅ | 451 tests pass ✅ | build ✅