### PR TITLE
feat: glob/negation patterns in render.frontmatter

### DIFF
--- a/packages/service/config.schema.json
+++ b/packages/service/config.schema.json
@@ -807,7 +807,7 @@
           "items": {
             "$ref": "#/definitions/__schema66"
           },
-          "description": "Keys to extract from context and include as YAML frontmatter."
+          "description": "Keys or glob patterns to include as YAML frontmatter. Supports picomatch globs (e.g. \"*\") and \"!\"-prefixed exclusion patterns (e.g. \"!_*\"). Explicit names preserve declaration order; glob-matched keys are sorted alphabetically."
         },
         "body": {
           "type": "array",

--- a/packages/service/src/config/schemas/inference.ts
+++ b/packages/service/src/config/schemas/inference.ts
@@ -109,10 +109,14 @@ export const renderBodySectionSchema = z.object({
 
 /** Render config: YAML frontmatter + ordered body sections. */
 export const renderConfigSchema = z.object({
-  /** Keys to extract from context and include as YAML frontmatter. */
+  /** Keys or glob patterns to extract from context and include as YAML frontmatter. */
   frontmatter: z
     .array(z.string().min(1))
-    .describe('Keys to extract from context and include as YAML frontmatter.'),
+    .describe(
+      'Keys or glob patterns to include as YAML frontmatter. ' +
+        'Supports picomatch globs (e.g. "*") and "!"-prefixed exclusion patterns (e.g. "!_*"). ' +
+        'Explicit names preserve declaration order; glob-matched keys are sorted alphabetically.',
+    ),
   /** Ordered markdown body sections. */
   body: z
     .array(renderBodySectionSchema)

--- a/packages/service/src/templates/renderDoc.test.ts
+++ b/packages/service/src/templates/renderDoc.test.ts
@@ -135,6 +135,30 @@ describe('renderDoc', () => {
     expect(bobIdx).toBeLessThan(charlieIdx);
   });
 
+  it('resolves glob patterns in frontmatter', () => {
+    const out = renderDoc(
+      {
+        meta_id: 'test-1',
+        name: 'Widget',
+        status: 'active',
+        _content: 'internal',
+        _error: null,
+        chunk_index: 3,
+      },
+      {
+        frontmatter: ['meta_id', '*', '!_*', '!chunk_*'],
+        body: [],
+      },
+      hbs,
+    );
+
+    expect(out).toContain('meta_id: test-1');
+    expect(out).toContain('name: Widget');
+    expect(out).toContain('status: active');
+    expect(out).not.toContain('_content');
+    expect(out).not.toContain('chunk_index');
+  });
+
   it('escapes frontmatter values that need quoting', () => {
     const out = renderDoc(
       { title: 'A: Dangerous Value' },

--- a/packages/service/src/templates/renderDoc.ts
+++ b/packages/service/src/templates/renderDoc.ts
@@ -12,6 +12,7 @@ import type {
   RenderConfig,
 } from '../config/schemas/inference';
 import { rebaseHeadings } from './rebaseHeadings';
+import { resolveFrontmatterKeys } from './resolveFrontmatterKeys';
 
 function renderSectionHeading(
   section: RenderBodySection,
@@ -115,9 +116,14 @@ export function renderDoc(
 ): string {
   const parts: string[] = [];
 
-  // Frontmatter
+  // Frontmatter — resolve patterns (globs, negations) against context keys.
+  const resolvedKeys = resolveFrontmatterKeys(
+    config.frontmatter,
+    Object.keys(context),
+  );
+
   const fmObj: Record<string, unknown> = {};
-  for (const key of config.frontmatter) {
+  for (const key of resolvedKeys) {
     const v = get(context, key);
     if (v !== undefined) {
       fmObj[key] = v;

--- a/packages/service/src/templates/resolveFrontmatterKeys.test.ts
+++ b/packages/service/src/templates/resolveFrontmatterKeys.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @module templates/resolveFrontmatterKeys.test
+ * Tests for resolveFrontmatterKeys.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveFrontmatterKeys } from './resolveFrontmatterKeys';
+
+describe('resolveFrontmatterKeys', () => {
+  const allKeys = [
+    'meta_id',
+    'meta_steer',
+    'name',
+    'type',
+    'status',
+    '_content',
+    '_error',
+    'chunk_index',
+    'file_path',
+  ];
+
+  it('returns explicit names in declaration order (backward compat)', () => {
+    expect(resolveFrontmatterKeys(['meta_id', 'name'], allKeys)).toEqual([
+      'meta_id',
+      'name',
+    ]);
+  });
+
+  it('expands * to all keys sorted alphabetically', () => {
+    const result = resolveFrontmatterKeys(['*'], allKeys);
+    expect(result).toEqual([...allKeys].sort());
+  });
+
+  it('applies ! exclusion patterns', () => {
+    const result = resolveFrontmatterKeys(['*', '!_*'], allKeys);
+    expect(result).not.toContain('_content');
+    expect(result).not.toContain('_error');
+    expect(result).toContain('meta_id');
+    expect(result).toContain('name');
+  });
+
+  it('combines explicit names, globs, and exclusions', () => {
+    const result = resolveFrontmatterKeys(
+      ['meta_id', '*', '!_*', '!chunk_*'],
+      allKeys,
+    );
+    // meta_id first (explicit), then remaining non-excluded sorted
+    expect(result[0]).toBe('meta_id');
+    expect(result).not.toContain('_content');
+    expect(result).not.toContain('_error');
+    expect(result).not.toContain('chunk_index');
+    expect(result).toContain('name');
+    expect(result).toContain('file_path');
+  });
+
+  it('excludes explicit names that match exclusion patterns', () => {
+    const result = resolveFrontmatterKeys(['_content', '!_*'], allKeys);
+    expect(result).toEqual([]);
+  });
+
+  it('handles empty context gracefully', () => {
+    expect(resolveFrontmatterKeys(['*'], [])).toEqual([]);
+  });
+
+  it('handles empty patterns gracefully', () => {
+    expect(resolveFrontmatterKeys([], allKeys)).toEqual([]);
+  });
+
+  it('ignores explicit names not present in context', () => {
+    expect(resolveFrontmatterKeys(['nonexistent', 'meta_id'], allKeys)).toEqual(
+      ['meta_id'],
+    );
+  });
+
+  it('deduplicates when explicit name also matches glob', () => {
+    const result = resolveFrontmatterKeys(['meta_id', '*'], allKeys);
+    const count = result.filter((k) => k === 'meta_id').length;
+    expect(count).toBe(1);
+    // meta_id should be first (explicit ordering)
+    expect(result[0]).toBe('meta_id');
+  });
+
+  it('supports prefix glob patterns', () => {
+    const result = resolveFrontmatterKeys(['meta_*'], allKeys);
+    expect(result).toEqual(['meta_id', 'meta_steer']);
+  });
+});

--- a/packages/service/src/templates/resolveFrontmatterKeys.ts
+++ b/packages/service/src/templates/resolveFrontmatterKeys.ts
@@ -1,0 +1,78 @@
+/**
+ * @module templates/resolveFrontmatterKeys
+ * Resolves frontmatter key patterns (with glob/negation support) against
+ * available context keys. Patterns prefixed with `!` are exclusions.
+ * Supports picomatch glob syntax (e.g. `*`, `_*`, `chunk_*`).
+ */
+
+import picomatch from 'picomatch';
+
+/**
+ * Resolve frontmatter patterns against available keys.
+ *
+ * @param patterns - Array of key names or glob patterns. `!`-prefixed patterns exclude.
+ * @param allKeys - All available keys from the rendering context.
+ * @returns Ordered array of resolved keys: explicit names in declaration order,
+ *   then glob-matched names sorted alphabetically, minus exclusions.
+ */
+export function resolveFrontmatterKeys(
+  patterns: string[],
+  allKeys: string[],
+): string[] {
+  const includes: string[] = [];
+  const excludePatterns: string[] = [];
+
+  for (const p of patterns) {
+    if (p.startsWith('!')) {
+      excludePatterns.push(p.slice(1));
+    } else {
+      includes.push(p);
+    }
+  }
+
+  const isExcluded = excludePatterns.length
+    ? picomatch(excludePatterns)
+    : () => false;
+
+  // Collect keys: explicit names first (in order), then glob-expanded (sorted).
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  // Pass 1: explicit (non-glob) names — preserved in declaration order.
+  const explicitNames: string[] = [];
+  const globPatterns: string[] = [];
+
+  for (const p of includes) {
+    if (isGlob(p)) {
+      globPatterns.push(p);
+    } else {
+      explicitNames.push(p);
+    }
+  }
+
+  for (const name of explicitNames) {
+    if (!isExcluded(name) && allKeys.includes(name) && !seen.has(name)) {
+      result.push(name);
+      seen.add(name);
+    }
+  }
+
+  // Pass 2: glob patterns — matched keys sorted alphabetically.
+  if (globPatterns.length) {
+    const isIncluded = picomatch(globPatterns);
+    const matched = allKeys.filter((k) => isIncluded(k)).sort();
+    for (const key of matched) {
+      if (!isExcluded(key) && !seen.has(key)) {
+        result.push(key);
+        seen.add(key);
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Check whether a pattern contains glob characters. */
+function isGlob(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern);
+}


### PR DESCRIPTION
Resolves #104.

## Summary

\ender.frontmatter\ now supports picomatch glob patterns and \!\-prefixed exclusion patterns in addition to explicit key names.

### Examples

| Pattern | Effect |
|---------|--------|
| \[meta_id, name]\ | Explicit keys only (existing behavior) |
| \[*]\ | All context keys |
| \[*, !_*]\ | All keys except those starting with \_\ |
| \[meta_id, *, !_*, !chunk_*]\ | \meta_id\ first, then all non-internal/non-chunk keys |

### Ordering
- Explicit names preserve declaration order
- Glob-matched keys sorted alphabetically
- Exclusions applied after expansion

### Changes
- **New:** \esolveFrontmatterKeys.ts\ — resolves patterns against available context keys using \picomatch\ (existing dep)
- **Modified:** \enderDoc.ts\ — delegates frontmatter key resolution to the new utility
- **Modified:** \inference.ts\ schema — updated \.describe()\ to document glob support
- **Tests:** 10 unit tests for the resolver + 1 integration test in renderDoc

### Backward Compatibility
Fully backward-compatible. Existing static key arrays produce identical results.