### PR TITLE
[107] fix: remove HTML escaping from renderDoc markdown output

### DIFF
--- a/packages/service/src/templates/renderDoc.test.ts
+++ b/packages/service/src/templates/renderDoc.test.ts
@@ -159,6 +159,30 @@ describe('renderDoc', () => {
     expect(out).not.toContain('chunk_index');
   });
 
+  it('preserves markdown in unformatted string body sections', () => {
+    const md =
+      '# Title\n\n```plantuml\n@startuml\nactor "Alice" as A\n@enduml\n```\n\nSome <html> & "quotes"';
+    const out = renderDoc(
+      { content: md },
+      {
+        frontmatter: [],
+        body: [{ path: 'content', heading: 2 }],
+      },
+      hbs,
+    );
+
+    // Markdown content must not be HTML-escaped
+    expect(out).toContain('```plantuml');
+    expect(out).toContain('"Alice"');
+    expect(out).toContain('<html>');
+    expect(out).toContain('& "quotes"');
+    // Must not contain HTML entities
+    expect(out).not.toContain('&#x60;');
+    expect(out).not.toContain('&quot;');
+    expect(out).not.toContain('&lt;');
+    expect(out).not.toContain('&amp;');
+  });
+
   it('escapes frontmatter values that need quoting', () => {
     const out = renderDoc(
       { title: 'A: Dangerous Value' },

--- a/packages/service/src/templates/renderDoc.ts
+++ b/packages/service/src/templates/renderDoc.ts
@@ -55,9 +55,11 @@ function renderValueAsMarkdown(
     return rebaseHeadings(md, section.heading);
   }
 
-  const strValue =
-    typeof value === 'string' ? value : JSON.stringify(value, null, 2);
-  return hbs.Utils.escapeExpression(strValue);
+  // Return string values as-is — renderDoc produces markdown, not HTML.
+  // HTML escaping (if needed) happens downstream when the markdown is rendered.
+  if (typeof value === 'string') return value;
+
+  return JSON.stringify(value, null, 2);
 }
 
 function renderEach(


### PR DESCRIPTION
## Summary

`renderValueAsMarkdown()` in `renderDoc.ts` was passing string values through `hbs.Utils.escapeExpression()`, which HTML-encodes backticks, angle brackets, quotes, and ampersands. Since `renderDoc` produces **markdown** (not HTML), this corrupted fenced code blocks, PlantUML diagrams, and any content containing special characters.

## Root Cause

The no-format path in `renderValueAsMarkdown` was:
```ts
const strValue = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
return hbs.Utils.escapeExpression(strValue);
```

`escapeExpression` converts backticks to `&#x60;`, `<`/`>` to `&lt;`/`&gt;`, quotes to `&quot;`, and `&` to `&amp;` — all appropriate for HTML contexts but destructive for markdown output.

## Fix

Return string values as-is and defer HTML escaping to the downstream markdown-to-HTML renderer (jeeves-server's `marked` pipeline). Non-string values get JSON-formatted without escaping.

## Testing

Added test case verifying that markdown content with fenced code blocks, angle brackets, quotes, and ampersands passes through without HTML entity encoding. All 476 existing tests continue to pass.

Fixes #107
