### PR TITLE
fix: add nocase to fileScan picomatch calls

### DIFF
--- a/packages/service/src/api/fileScan.ts
+++ b/packages/service/src/api/fileScan.ts
@@ -60,9 +60,9 @@ export async function listFilesFromGlobs(
   const normPatterns = patterns.map((p) => normalizeSlashes(p));
   const normIgnored = ignored.map((p) => normalizeSlashes(p));
 
-  const match = picomatch(normPatterns, { dot: true });
+  const match = picomatch(normPatterns, { dot: true, nocase: true });
   const ignore = normIgnored.length
-    ? picomatch(normIgnored, { dot: true })
+    ? picomatch(normIgnored, { dot: true, nocase: true })
     : () => false;
 
   const bases = Array.from(new Set(patterns.map(globBase)));


### PR DESCRIPTION
Closes #114

**Root cause:** `listFilesFromGlobs` in `fileScan.ts` used `picomatch(patterns, { dot: true })` without `nocase: true`. On Windows, `path.resolve()` uppercases drive letters (`J:`), but config globs use lowercase (`j:`), so picomatch rejected every file during reindex.

The chokidar watcher path (`globToDir.ts`) already had `nocase: true`, so incremental file watching worked. Only reindex/processAllFiles was affected.

**Fix:** Add `nocase: true` to both picomatch calls in `fileScan.ts`.