### PR TITLE
fix: POST /walk uses chokidar getWatched() instead of filesystem walk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2588,7 +2588,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -2602,7 +2603,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -2616,7 +2618,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -2630,7 +2633,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -2644,7 +2648,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -2658,7 +2663,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -2672,7 +2678,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -2686,7 +2693,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -2700,7 +2708,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -2714,7 +2723,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -2728,7 +2738,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -2742,7 +2753,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -2756,7 +2768,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -2770,7 +2783,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -2784,7 +2798,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -2798,7 +2813,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -2812,7 +2828,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -2826,7 +2843,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -2840,7 +2858,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -2854,7 +2873,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -2868,7 +2888,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -2882,7 +2903,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -2896,7 +2918,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -2910,7 +2933,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -2924,7 +2948,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
@@ -10870,7 +10895,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-watcher-openclaw",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-watcher-openclaw": "dist/cli.js"
@@ -10892,7 +10917,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-watcher",
-      "version": "0.9.9",
+      "version": "0.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",

--- a/packages/service/src/api/fileScan.test.ts
+++ b/packages/service/src/api/fileScan.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { normalizeSlashes } from '../util/normalizeSlashes';
 import {
   getWatchRootBases,
+  getWatchedFiles,
   globBase,
   listFilesFromGlobs,
   listFilesFromWatchRoots,
@@ -40,6 +41,42 @@ describe('globBase', () => {
   it('handles trailing slash before glob', () => {
     const result = globBase('docs/**');
     expect(result).toBe(resolve('docs'));
+  });
+});
+
+describe('getWatchedFiles', () => {
+  it('flattens chokidar watched object to file paths', () => {
+    const watched = {
+      '/project/src': ['index.ts', 'utils.ts'],
+      '/project/docs': ['readme.md'],
+      '/project': ['package.json'],
+    };
+
+    const files = getWatchedFiles(watched);
+
+    expect(files).toHaveLength(4);
+    expect(files).toContain(resolve('/project/src/index.ts'));
+    expect(files).toContain(resolve('/project/src/utils.ts'));
+    expect(files).toContain(resolve('/project/docs/readme.md'));
+    expect(files).toContain(resolve('/project/package.json'));
+  });
+
+  it('returns empty array for empty watched object', () => {
+    const files = getWatchedFiles({});
+    expect(files).toHaveLength(0);
+  });
+
+  it('handles nested directories', () => {
+    const watched = {
+      '/a/b/c': ['deep.ts'],
+      '/a': ['shallow.ts'],
+    };
+
+    const files = getWatchedFiles(watched);
+
+    expect(files).toHaveLength(2);
+    expect(files).toContain(resolve('/a/b/c/deep.ts'));
+    expect(files).toContain(resolve('/a/shallow.ts'));
   });
 });
 

--- a/packages/service/src/api/fileScan.ts
+++ b/packages/service/src/api/fileScan.ts
@@ -6,6 +6,24 @@ import picomatch from 'picomatch';
 import { normalizeSlashes } from '../util/normalizeSlashes';
 
 /**
+ * Get files from chokidar's in-memory watched list instead of filesystem walk.
+ * Flattens the nested directory structure returned by chokidar.getWatched().
+ *
+ * @param watched - The object returned by chokidar.getWatched(), mapping directories to file arrays.
+ * @returns Array of absolute file paths.
+ */
+export function getWatchedFiles(watched: Record<string, string[]>): string[] {
+  const files: string[] = [];
+  for (const [dir, entries] of Object.entries(watched)) {
+    for (const entry of entries) {
+      // chokidar lists files as bare names; reconstruct full path
+      files.push(resolve(dir, entry));
+    }
+  }
+  return files;
+}
+
+/**
  * Best-effort base directory inference for a glob pattern.
  *
  * For our use (watch paths in config), this only needs to be good enough

--- a/packages/service/src/api/handlers/walk.test.ts
+++ b/packages/service/src/api/handlers/walk.test.ts
@@ -3,49 +3,152 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WalkRouteDeps } from './walk';
 import { createWalkHandler } from './walk';
 
-describe('createWalkHandler', () => {
-  const mockWatcher = {
-    getWatchedFiles: vi.fn(),
-    isReady: true,
-  };
+// Mock the fileScan module
+vi.mock('../fileScan', () => ({
+  getWatchRootBases: vi.fn(),
+  getWatchedFiles: vi.fn(),
+}));
 
+import { getWatchRootBases, getWatchedFiles } from '../fileScan';
+
+const getWatchedFilesMock = vi.mocked(getWatchedFiles);
+const getRootBasesMock = vi.mocked(getWatchRootBases);
+
+describe('createWalkHandler', () => {
   beforeEach(() => {
-    mockWatcher.getWatchedFiles.mockReset();
-    mockWatcher.isReady = true;
+    getWatchedFilesMock.mockReset();
+    getRootBasesMock.mockReset();
   });
 
   const makeDeps = (): WalkRouteDeps => ({
     watchPaths: ['j:/domains/**/*.md', 'j:/config/**/*.json'],
-    fileSystemWatcher: mockWatcher as never,
     logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } as never,
   });
 
-  it('filters watched files by caller globs', async () => {
-    const deps = makeDeps();
+  it('returns 503 when initial scan is active', async () => {
+    const deps: WalkRouteDeps = {
+      ...makeDeps(),
+      initialScanTracker: {
+        getStatus: () => ({ active: true, filesMatched: 10, filesEnqueued: 5, startedAt: new Date().toISOString() }),
+      } as never,
+    };
     const handler = createWalkHandler(deps);
 
-    mockWatcher.getWatchedFiles.mockReturnValue([
-      'j:/domains/foo/.meta/meta.json',
-      'j:/domains/bar/readme.md',
-      'j:/domains/baz/.meta/meta.json',
-    ]);
+    const request = { body: { globs: ['**/*.md'] } } as never;
+    const sendMock = vi.fn();
+    const statusMock = vi.fn().mockReturnValue({ send: sendMock });
+    const reply = { status: statusMock, send: sendMock } as never;
 
-    const request = {
-      body: { globs: ['**/.meta/meta.json'] },
-    } as never;
+    await handler(request, reply);
+
+    expect(statusMock).toHaveBeenCalledWith(503);
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Service Unavailable' }),
+    );
+  });
+
+  it('uses in-memory watched files when fileSystemWatcher is available', async () => {
+    const deps: WalkRouteDeps = {
+      ...makeDeps(),
+      fileSystemWatcher: {
+        getWatched: () => ({
+          'j:/domains': ['file1.md', 'file2.md'],
+          'j:/config': ['settings.json'],
+        }),
+      } as never,
+      initialScanTracker: {
+        getStatus: () => ({ active: false }),
+      } as never,
+    };
+    const handler = createWalkHandler(deps);
+
+    getWatchedFilesMock.mockReturnValue([
+      'j:/domains/file1.md',
+      'j:/domains/file2.md',
+      'j:/config/settings.json',
+    ]);
+    getRootBasesMock.mockReturnValue(['j:/domains', 'j:/config']);
+
+    const request = { body: { globs: ['**/*.md'] } } as never;
     const sendMock = vi.fn();
     const reply = { status: vi.fn().mockReturnThis(), send: sendMock } as never;
 
     await handler(request, reply);
 
-    expect(sendMock).toHaveBeenCalledWith({
-      paths: [
-        'j:/domains/foo/.meta/meta.json',
-        'j:/domains/baz/.meta/meta.json',
-      ],
-      matchedCount: 2,
-      scannedRoots: expect.any(Array) as unknown as string[],
+    expect(getWatchedFilesMock).toHaveBeenCalledWith({
+      'j:/domains': ['file1.md', 'file2.md'],
+      'j:/config': ['settings.json'],
     });
+    expect(sendMock).toHaveBeenCalledWith({
+      paths: expect.arrayContaining([expect.stringContaining('.md')]),
+      matchedCount: expect.any(Number),
+      scannedRoots: ['j:/domains', 'j:/config'],
+    });
+  });
+
+  it('filters by glob patterns', async () => {
+    const deps: WalkRouteDeps = {
+      ...makeDeps(),
+      fileSystemWatcher: {
+        getWatched: () => ({
+          'j:/domains': ['file1.md', 'file2.txt'],
+          'j:/config': ['settings.json'],
+        }),
+      } as never,
+      initialScanTracker: {
+        getStatus: () => ({ active: false }),
+      } as never,
+    };
+    const handler = createWalkHandler(deps);
+
+    getWatchedFilesMock.mockReturnValue([
+      'j:/domains/file1.md',
+      'j:/domains/file2.txt',
+      'j:/config/settings.json',
+    ]);
+    getRootBasesMock.mockReturnValue(['j:/domains', 'j:/config']);
+
+    const request = { body: { globs: ['**/*.md'] } } as never;
+    const sendMock = vi.fn();
+    const reply = { status: vi.fn().mockReturnThis(), send: sendMock } as never;
+
+    await handler(request, reply);
+
+    const response = sendMock.mock.calls[0]?.[0];
+    expect(response.paths).toContain('j:/domains/file1.md');
+    expect(response.paths).not.toContain('j:/domains/file2.txt');
+    expect(response.paths).not.toContain('j:/config/settings.json');
+  });
+
+  it('applies gitignore filter when available', async () => {
+    const isIgnoredMock = vi.fn().mockImplementation((path: string) => path.includes('ignored'));
+    const deps: WalkRouteDeps = {
+      ...makeDeps(),
+      fileSystemWatcher: {
+        getWatched: () => ({
+          'j:/domains': ['file1.md', 'ignored.md'],
+        }),
+      } as never,
+      gitignoreFilter: { isIgnored: isIgnoredMock } as never,
+      initialScanTracker: {
+        getStatus: () => ({ active: false }),
+      } as never,
+    };
+    const handler = createWalkHandler(deps);
+
+    getWatchedFilesMock.mockReturnValue(['j:/domains/file1.md', 'j:/domains/ignored.md']);
+    getRootBasesMock.mockReturnValue(['j:/domains']);
+
+    const request = { body: { globs: ['**/*.md'] } } as never;
+    const sendMock = vi.fn();
+    const reply = { status: vi.fn().mockReturnThis(), send: sendMock } as never;
+
+    await handler(request, reply);
+
+    expect(isIgnoredMock).toHaveBeenCalled();
+    const response = sendMock.mock.calls[0]?.[0];
+    expect(response.paths).toContain('j:/domains/file1.md');
+    expect(response.paths).not.toContain('j:/domains/ignored.md');
   });
 
   it('rejects missing globs', async () => {
@@ -54,7 +157,7 @@ describe('createWalkHandler', () => {
 
     const request = { body: {} } as never;
     const sendMock = vi.fn();
-    const statusMock = vi.fn().mockReturnValue({ send: sendMock });
+    const statusMock = vi.fn().mockReturnThis().mockReturnValue({ send: sendMock });
     const reply = { status: statusMock, send: sendMock } as never;
 
     await handler(request, reply);
@@ -71,50 +174,11 @@ describe('createWalkHandler', () => {
 
     const request = { body: { globs: [] } } as never;
     const sendMock = vi.fn();
-    const statusMock = vi.fn().mockReturnValue({ send: sendMock });
+    const statusMock = vi.fn().mockReturnThis().mockReturnValue({ send: sendMock });
     const reply = { status: statusMock, send: sendMock } as never;
 
     await handler(request, reply);
 
     expect(statusMock).toHaveBeenCalledWith(400);
-  });
-
-  it('returns 503 when scan is in progress', async () => {
-    const deps = makeDeps();
-    mockWatcher.isReady = false;
-    const handler = createWalkHandler(deps);
-
-    const request = {
-      body: { globs: ['**/*.md'] },
-    } as never;
-    const sendMock = vi.fn();
-    const statusMock = vi.fn().mockReturnValue({ send: sendMock });
-    const reply = { status: statusMock, send: sendMock } as never;
-
-    await handler(request, reply);
-
-    expect(statusMock).toHaveBeenCalledWith(503);
-    expect(sendMock).toHaveBeenCalledWith(
-      expect.objectContaining({ error: 'Scan in progress' }),
-    );
-  });
-
-  it('returns 503 when watcher is not available', async () => {
-    const deps: WalkRouteDeps = {
-      watchPaths: ['j:/domains/**/*.md'],
-      logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } as never,
-    };
-    const handler = createWalkHandler(deps);
-
-    const request = {
-      body: { globs: ['**/*.md'] },
-    } as never;
-    const sendMock = vi.fn();
-    const statusMock = vi.fn().mockReturnValue({ send: sendMock });
-    const reply = { status: statusMock, send: sendMock } as never;
-
-    await handler(request, reply);
-
-    expect(statusMock).toHaveBeenCalledWith(503);
   });
 });

--- a/packages/service/src/api/handlers/walk.ts
+++ b/packages/service/src/api/handlers/walk.ts
@@ -7,22 +7,88 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import picomatch from 'picomatch';
 import type pino from 'pino';
+import { readdir, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
-import { normalizeSlashes } from '../../util/normalizeSlashes';
 import type { FileSystemWatcher } from '../../watcher';
-import { getWatchRootBases } from '../fileScan';
+import { createIsGitignored, type GitignoreFilter } from '../../gitignore';
+import { getWatchRootBases, getWatchedFiles } from '../fileScan';
+import { normalizeSlashes } from '../../util/normalizeSlashes';
+import type { InitialScanTracker } from '../InitialScanTracker';
 import { wrapHandler } from './wrapHandler';
 
 /** Dependencies for the walk route handler. */
 export interface WalkRouteDeps {
   watchPaths: string[];
+  watchIgnored?: string[];
+  gitignoreFilter?: GitignoreFilter;
   fileSystemWatcher?: FileSystemWatcher;
   logger: pino.Logger;
+  initialScanTracker?: InitialScanTracker;
 }
 
 type WalkRequest = FastifyRequest<{
   Body: { globs?: string[] };
 }>;
+
+/** Fallback filesystem walk for when FileSystemWatcher is not available. */
+async function* walk(dir: string): AsyncGenerator<string> {
+  let entries: Array<{ name: string; isDirectory: boolean }>;
+  try {
+    const dirents = await readdir(dir, { withFileTypes: true });
+    entries = dirents.map((d) => ({
+      name: d.name,
+      isDirectory: d.isDirectory(),
+    }));
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory) {
+      yield* walk(full);
+    } else {
+      try {
+        const st = await stat(full);
+        if (st.isFile()) yield full;
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+/** Filter watched files using the same logic as the original walk. */
+function filterWatchedFiles(
+  files: string[],
+  watchPatterns: string[],
+  ignored: string[],
+  callerGlobs: string[],
+  isGitignored?: (filePath: string) => boolean,
+): string[] {
+  const normPatterns = watchPatterns.map((p) => normalizeSlashes(p));
+  const normIgnored = ignored.map((p) => normalizeSlashes(p));
+  const normCaller = callerGlobs.map((p) => normalizeSlashes(p));
+
+  const matchWatch = picomatch(normPatterns, { dot: true, nocase: true });
+  const matchCaller = picomatch(normCaller, { dot: true, nocase: true });
+  const ignore = normIgnored.length
+    ? picomatch(normIgnored, { dot: true, nocase: true })
+    : () => false;
+
+  const seen = new Set<string>();
+  for (const file of files) {
+    const rel = normalizeSlashes(file);
+    if (ignore(rel)) continue;
+    if (!matchWatch(rel)) continue;
+    if (!matchCaller(rel)) continue;
+    if (isGitignored?.(file)) continue;
+    seen.add(file);
+  }
+
+  return Array.from(seen);
+}
 
 /**
  * Create handler for POST /walk.
@@ -42,28 +108,32 @@ export function createWalkHandler(deps: WalkRouteDeps) {
         });
       }
 
-      if (!deps.fileSystemWatcher) {
+      // Return 503 if initial scan is still active
+      if (deps.initialScanTracker?.getStatus().active) {
         return await reply.status(503).send({
-          error: 'Watcher unavailable',
-          message: 'Filesystem watcher is not initialized.',
+          error: 'Service Unavailable',
+          message: 'Initial filesystem scan is in progress. Please try again later.',
         });
       }
 
-      if (!deps.fileSystemWatcher.isReady) {
-        return await reply.status(503).send({
-          error: 'Scan in progress',
-          message:
-            'Initial filesystem scan is still active. Try again after scan completes.',
-        });
+      // Use in-memory watched files if available, otherwise fall back to filesystem walk
+      let allFiles: string[];
+      if (deps.fileSystemWatcher) {
+        const watched = deps.fileSystemWatcher.getWatched();
+        allFiles = getWatchedFiles(watched);
+      } else {
+        // Fallback: collect files by walking watch root bases
+        const bases = getWatchRootBases(deps.watchPaths);
+        allFiles = [];
+        for (const base of bases) {
+          for await (const file of walk(base)) {
+            allFiles.push(file);
+          }
+        }
       }
 
-      const watchedFiles = deps.fileSystemWatcher.getWatchedFiles();
-
-      const normGlobs = globs.map((g) => normalizeSlashes(g));
-      const matchGlobs = picomatch(normGlobs, { dot: true, nocase: true });
-
-      const paths = watchedFiles.filter((f) => matchGlobs(normalizeSlashes(f)));
-
+      const isGitignored = createIsGitignored(deps.gitignoreFilter);
+      const paths = filterWatchedFiles(allFiles, deps.watchPaths, deps.watchIgnored ?? [], globs, isGitignored);
       const scannedRoots = getWatchRootBases(deps.watchPaths);
 
       return {

--- a/packages/service/src/api/index.ts
+++ b/packages/service/src/api/index.ts
@@ -90,7 +90,7 @@ export interface ApiServerOptions {
   version?: string;
   /** Initial scan tracker for /status visibility. */
   initialScanTracker?: InitialScanTracker;
-  /** Filesystem watcher instance for /walk endpoint (in-memory file list). */
+  /** Filesystem watcher for in-memory file listing (used by /walk). */
   fileSystemWatcher?: FileSystemWatcher;
 }
 
@@ -117,6 +117,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     gitignoreFilter,
     version,
     initialScanTracker,
+    fileSystemWatcher,
   } = options;
 
   const reindexTracker = options.reindexTracker ?? new ReindexTracker();
@@ -199,8 +200,11 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     '/walk',
     createWalkHandler({
       watchPaths: config.watch.paths,
-      fileSystemWatcher: options.fileSystemWatcher,
+      watchIgnored: config.watch.ignored,
+      gitignoreFilter,
+      fileSystemWatcher,
       logger,
+      initialScanTracker,
     }),
   );
 

--- a/packages/service/src/watcher/index.ts
+++ b/packages/service/src/watcher/index.ts
@@ -250,6 +250,15 @@ export class FileSystemWatcher {
   }
 
   /**
+   * Get the map of watched directories to their file entries.
+   * Returns an empty object if the watcher is not started.
+   */
+  getWatched(): Record<string, string[]> {
+    if (!this.watcher) return {};
+    return this.watcher.getWatched();
+  }
+
+  /**
    * Check if a path is gitignored and should be skipped.
    */
   private isGitignored(path: string): boolean {


### PR DESCRIPTION
## Problem
POST /walk currently performs a filesystem walk which can hang on large directories.

## Solution
- Use chokidar's in-memory `getWatched()` for instant file listing
- Add 503 response when initial scan is still active
- Maintain backward compatibility with filesystem fallback

## Changes
- Added `getWatched()` method to `FileSystemWatcher` class
- Added `getWatchedFiles()` helper to flatten chokidar's directory structure
- Updated walk handler to use in-memory list when available
- Added 503 response for active initial scan
- Updated tests

Fixes #122