### PR TITLE
fix: Linux CI compatibility — cross-platform path test and skip integration tests without Qdrant

### DIFF
--- a/packages/service/src/app/initialization.test.ts
+++ b/packages/service/src/app/initialization.test.ts
@@ -67,7 +67,7 @@ describe('resolveMapsConfig', () => {
 describe('getConfigDir', () => {
   it('should return directory from config path', () => {
     expect(getConfigDir('/path/to/config.json')).toBe('/path/to');
-    expect(getConfigDir('C:\\configs\\jeeves.yaml')).toBe('C:\\configs');
+    expect(getConfigDir('/configs/jeeves.yaml')).toBe('/configs');
   });
 
   it('should return "." when no config path provided', () => {

--- a/packages/service/src/test/gitignore-integration.test.ts
+++ b/packages/service/src/test/gitignore-integration.test.ts
@@ -25,119 +25,134 @@ import {
   setupTestDirs,
 } from './helpers';
 
-const config = createTestConfig();
-// Use a separate collection to avoid conflicts with parallel test files
-config.vectorStore.collectionName = 'jeeves_watcher_test_gitignore';
-const embeddingProvider = createEmbeddingProvider(config.embedding);
-const logger = createLogger({ level: 'silent' });
+const skipIntegration = process.env['QDRANT_AVAILABLE'] !== 'true';
 
-let vectorStore: VectorStoreClient;
-let processor: DocumentProcessor;
+describe.skipIf(skipIntegration)(
+  'Gitignore integration tests (requires Qdrant)',
+  () => {
+    const config = createTestConfig();
+    // Use a separate collection to avoid conflicts with parallel test files
+    config.vectorStore.collectionName = 'jeeves_watcher_test_gitignore';
+    const embeddingProvider = createEmbeddingProvider(config.embedding);
+    const logger = createLogger({ level: 'silent' });
 
-beforeAll(async () => {
-  vectorStore = new VectorStoreClient(
-    config.vectorStore,
-    embeddingProvider.dimensions,
-  );
+    let vectorStore: VectorStoreClient;
+    let processor: DocumentProcessor;
 
-  const url = config.vectorStore.url;
-  const collectionName = config.vectorStore.collectionName;
-  try {
-    await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
-  } catch {
-    // ignore
-  }
-  await vectorStore.ensureCollection();
+    beforeAll(async () => {
+      vectorStore = new VectorStoreClient(
+        config.vectorStore,
+        embeddingProvider.dimensions,
+      );
 
-  const compiledRules = compileRules(config.inferenceRules ?? []);
-  const processorConfig = {
-    chunkSize: config.embedding.chunkSize,
-    chunkOverlap: config.embedding.chunkOverlap,
-    maps: config.maps,
-  };
-
-  processor = new DocumentProcessor({
-    config: processorConfig,
-    embeddingProvider,
-    vectorStore,
-    compiledRules,
-    logger,
-  });
-});
-
-afterAll(async () => {
-  const url = config.vectorStore.url;
-  const collectionName = config.vectorStore.collectionName;
-  try {
-    await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
-  } catch {
-    // ignore
-  }
-});
-
-beforeEach(async () => {
-  await setupTestDirs();
-});
-
-afterEach(async () => {
-  const url = config.vectorStore.url;
-  const collectionName = config.vectorStore.collectionName;
-  try {
-    await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
-  } catch {
-    // ignore
-  }
-  await vectorStore.ensureCollection();
-  await cleanupWatchedDir();
-});
-
-describe('Gitignore filtering integration', () => {
-  it('should only index non-ignored files when filter is applied', async () => {
-    const watchDir = getWatchDir();
-
-    // Create a fake git repo structure
-    await mkdir(join(watchDir, '.git'), { recursive: true });
-    await writeFile(join(watchDir, '.gitignore'), '*.log\ndist/\n', 'utf8');
-
-    // Create files: one tracked, two ignored
-    await mkdir(join(watchDir, 'src'), { recursive: true });
-    await mkdir(join(watchDir, 'dist'), { recursive: true });
-
-    const trackedFile = join(watchDir, 'src', 'index.ts');
-    const ignoredLog = join(watchDir, 'error.log');
-    const ignoredDist = join(watchDir, 'dist', 'bundle.js');
-
-    await writeFile(trackedFile, 'export const hello = "world";', 'utf8');
-    await writeFile(ignoredLog, 'ERROR: something broke', 'utf8');
-    await writeFile(ignoredDist, 'var x=1;', 'utf8');
-
-    // Create GitignoreFilter scoped to watchDir
-    const filter = new GitignoreFilter([watchDir]);
-
-    // Verify filter decisions
-    expect(filter.isIgnored(trackedFile)).toBe(false);
-    expect(filter.isIgnored(ignoredLog)).toBe(true);
-    expect(filter.isIgnored(ignoredDist)).toBe(true);
-
-    // Process only non-ignored files (mirrors watcher behavior)
-    const allFiles = [trackedFile, ignoredLog, ignoredDist];
-    for (const filePath of allFiles) {
-      if (!filter.isIgnored(filePath)) {
-        await processor.processFile(filePath);
+      const url = config.vectorStore.url;
+      const collectionName = config.vectorStore.collectionName;
+      try {
+        await fetch(`${url}/collections/${collectionName}`, {
+          method: 'DELETE',
+        });
+      } catch {
+        // ignore
       }
-    }
+      await vectorStore.ensureCollection();
 
-    // Verify Qdrant state: only tracked file indexed
-    const trackedPayload = await vectorStore.getPayload(
-      pointId(trackedFile, 0),
-    );
-    expect(trackedPayload).not.toBeNull();
-    expect(trackedPayload!['chunk_text']).toContain('hello');
+      const compiledRules = compileRules(config.inferenceRules ?? []);
+      const processorConfig = {
+        chunkSize: config.embedding.chunkSize,
+        chunkOverlap: config.embedding.chunkOverlap,
+        maps: config.maps,
+      };
 
-    const logPayload = await vectorStore.getPayload(pointId(ignoredLog, 0));
-    expect(logPayload).toBeNull();
+      processor = new DocumentProcessor({
+        config: processorConfig,
+        embeddingProvider,
+        vectorStore,
+        compiledRules,
+        logger,
+      });
+    });
 
-    const distPayload = await vectorStore.getPayload(pointId(ignoredDist, 0));
-    expect(distPayload).toBeNull();
-  });
-});
+    afterAll(async () => {
+      const url = config.vectorStore.url;
+      const collectionName = config.vectorStore.collectionName;
+      try {
+        await fetch(`${url}/collections/${collectionName}`, {
+          method: 'DELETE',
+        });
+      } catch {
+        // ignore
+      }
+    });
+
+    beforeEach(async () => {
+      await setupTestDirs();
+    });
+
+    afterEach(async () => {
+      const url = config.vectorStore.url;
+      const collectionName = config.vectorStore.collectionName;
+      try {
+        await fetch(`${url}/collections/${collectionName}`, {
+          method: 'DELETE',
+        });
+      } catch {
+        // ignore
+      }
+      await vectorStore.ensureCollection();
+      await cleanupWatchedDir();
+    });
+
+    describe('Gitignore filtering integration', () => {
+      it('should only index non-ignored files when filter is applied', async () => {
+        const watchDir = getWatchDir();
+
+        // Create a fake git repo structure
+        await mkdir(join(watchDir, '.git'), { recursive: true });
+        await writeFile(join(watchDir, '.gitignore'), '*.log\ndist/\n', 'utf8');
+
+        // Create files: one tracked, two ignored
+        await mkdir(join(watchDir, 'src'), { recursive: true });
+        await mkdir(join(watchDir, 'dist'), { recursive: true });
+
+        const trackedFile = join(watchDir, 'src', 'index.ts');
+        const ignoredLog = join(watchDir, 'error.log');
+        const ignoredDist = join(watchDir, 'dist', 'bundle.js');
+
+        await writeFile(trackedFile, 'export const hello = "world";', 'utf8');
+        await writeFile(ignoredLog, 'ERROR: something broke', 'utf8');
+        await writeFile(ignoredDist, 'var x=1;', 'utf8');
+
+        // Create GitignoreFilter scoped to watchDir
+        const filter = new GitignoreFilter([watchDir]);
+
+        // Verify filter decisions
+        expect(filter.isIgnored(trackedFile)).toBe(false);
+        expect(filter.isIgnored(ignoredLog)).toBe(true);
+        expect(filter.isIgnored(ignoredDist)).toBe(true);
+
+        // Process only non-ignored files (mirrors watcher behavior)
+        const allFiles = [trackedFile, ignoredLog, ignoredDist];
+        for (const filePath of allFiles) {
+          if (!filter.isIgnored(filePath)) {
+            await processor.processFile(filePath);
+          }
+        }
+
+        // Verify Qdrant state: only tracked file indexed
+        const trackedPayload = await vectorStore.getPayload(
+          pointId(trackedFile, 0),
+        );
+        expect(trackedPayload).not.toBeNull();
+        expect(trackedPayload!['chunk_text']).toContain('hello');
+
+        const logPayload = await vectorStore.getPayload(pointId(ignoredLog, 0));
+        expect(logPayload).toBeNull();
+
+        const distPayload = await vectorStore.getPayload(
+          pointId(ignoredDist, 0),
+        );
+        expect(distPayload).toBeNull();
+      });
+    });
+  },
+);

--- a/packages/service/src/test/globalSetup.ts
+++ b/packages/service/src/test/globalSetup.ts
@@ -1,0 +1,26 @@
+/**
+ * @module test/globalSetup
+ * Vitest global setup: probes Qdrant availability and sets QDRANT_AVAILABLE env var.
+ * Integration tests use this flag to skip when Qdrant is not reachable.
+ */
+
+export async function setup(): Promise<void> {
+  const url = process.env['QDRANT_URL'] ?? 'http://localhost:6333';
+
+  try {
+    const res = await fetch(`${url}/healthz`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (res.ok) {
+      process.env['QDRANT_AVAILABLE'] = 'true';
+      return;
+    }
+  } catch {
+    // Qdrant unreachable
+  }
+
+  process.env['QDRANT_AVAILABLE'] = 'false';
+  console.warn(
+    `[globalSetup] Qdrant not reachable at ${url} — integration tests will be skipped.`,
+  );
+}

--- a/packages/service/src/test/helpers.ts
+++ b/packages/service/src/test/helpers.ts
@@ -4,6 +4,26 @@ import { join } from 'node:path';
 
 import type { JeevesWatcherConfig } from '../config/types';
 
+/**
+ * Check whether Qdrant is reachable at the given URL.
+ * Used to skip integration tests in CI environments without Qdrant.
+ *
+ * @param url - Qdrant base URL (e.g. "http://localhost:6333")
+ * @returns true if Qdrant responds to a health check, false otherwise.
+ */
+export async function isQdrantAvailable(
+  url = 'http://localhost:6333',
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${url}/healthz`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 const TEST_BASE = join(tmpdir(), 'jeeves-watcher-test');
 
 /**

--- a/packages/service/src/test/integration.test.ts
+++ b/packages/service/src/test/integration.test.ts
@@ -30,517 +30,530 @@ import {
   setupTestDirs,
 } from './helpers';
 
-const config = createTestConfig();
-const embeddingProvider = createEmbeddingProvider(config.embedding);
-const logger = createLogger({ level: 'silent' });
+const skipIntegration = process.env['QDRANT_AVAILABLE'] !== 'true';
 
-let vectorStore: VectorStoreClient;
-let processor: DocumentProcessor;
-let enrichmentStore: EnrichmentStore;
+describe.skipIf(skipIntegration)('Integration tests (requires Qdrant)', () => {
+  const config = createTestConfig();
+  const embeddingProvider = createEmbeddingProvider(config.embedding);
+  const logger = createLogger({ level: 'silent' });
 
-beforeAll(async () => {
-  vectorStore = new VectorStoreClient(
-    config.vectorStore,
-    embeddingProvider.dimensions,
-  );
+  let vectorStore: VectorStoreClient;
+  let processor: DocumentProcessor;
+  let enrichmentStore: EnrichmentStore;
 
-  // Use raw Qdrant HTTP to ensure clean collection
-  const url = config.vectorStore.url;
-  const collectionName = config.vectorStore.collectionName;
-  try {
-    await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
-  } catch {
-    // ignore
-  }
-  await vectorStore.ensureCollection();
-
-  const compiledRules = compileRules(config.inferenceRules ?? []);
-
-  const stateDir = config.stateDir ?? '.jeeves-metadata';
-  enrichmentStore = new EnrichmentStore(stateDir);
-
-  const processorConfig = {
-    chunkSize: config.embedding.chunkSize,
-    chunkOverlap: config.embedding.chunkOverlap,
-    maps: config.maps,
-  };
-
-  processor = new DocumentProcessor({
-    config: processorConfig,
-    embeddingProvider,
-    vectorStore,
-    compiledRules,
-    logger,
-    enrichmentStore,
-  });
-});
-
-afterAll(async () => {
-  enrichmentStore.close();
-  const url = config.vectorStore.url;
-  const collectionName = config.vectorStore.collectionName;
-  try {
-    await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
-  } catch {
-    // ignore
-  }
-  await cleanupTestDirs();
-});
-
-beforeEach(async () => {
-  await setupTestDirs();
-});
-
-afterEach(async () => {
-  // Clear all points from collection
-  const url = config.vectorStore.url;
-  const collectionName = config.vectorStore.collectionName;
-  try {
-    await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
-  } catch {
-    // ignore
-  }
-  await vectorStore.ensureCollection();
-  await cleanupWatchedDir();
-});
-
-describe('File add', () => {
-  it('should index a new file with correct payload fields', async () => {
-    const filePath = join(getWatchDir(), 'test.txt');
-    await writeFile(filePath, 'Hello world, this is a test document.', 'utf8');
-
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    const payload = await vectorStore.getPayload(id);
-
-    expect(payload).not.toBeNull();
-    expect(payload!['file_path']).toBe(filePath.replace(/\\/g, '/'));
-    expect(payload!['chunk_index']).toBe(0);
-    expect(payload!['content_hash']).toBeTypeOf('string');
-    expect(payload!['chunk_text']).toContain('Hello world');
-  });
-});
-
-describe('File update', () => {
-  it('should re-embed when content changes', async () => {
-    const filePath = join(getWatchDir(), 'update.txt');
-    await writeFile(filePath, 'Original content here.', 'utf8');
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    const payload1 = await vectorStore.getPayload(id);
-    const hash1 = payload1!['content_hash'];
-
-    await writeFile(filePath, 'Updated content that is different.', 'utf8');
-    await processor.processFile(filePath);
-
-    const payload2 = await vectorStore.getPayload(id);
-    expect(payload2!['content_hash']).not.toBe(hash1);
-    expect(payload2!['chunk_text']).toContain('Updated content');
-  });
-
-  it('should skip re-embedding when content is unchanged', async () => {
-    const filePath = join(getWatchDir(), 'same.txt');
-    await writeFile(filePath, 'Same content.', 'utf8');
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    const payload1 = await vectorStore.getPayload(id);
-
-    // Process again — should skip (content hash matches)
-    await processor.processFile(filePath);
-
-    const payload2 = await vectorStore.getPayload(id);
-    expect(payload2!['content_hash']).toBe(payload1!['content_hash']);
-  });
-});
-
-describe('File delete', () => {
-  it('should remove chunks from Qdrant', async () => {
-    const filePath = join(getWatchDir(), 'delete-me.txt');
-    await writeFile(filePath, 'Content to be deleted.', 'utf8');
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    expect(await vectorStore.getPayload(id)).not.toBeNull();
-
-    await processor.deleteFile(filePath);
-    expect(await vectorStore.getPayload(id)).toBeNull();
-  });
-});
-
-describe('Metadata update', () => {
-  it('should update Qdrant payloads without re-embedding', async () => {
-    const filePath = join(getWatchDir(), 'meta.txt');
-    await writeFile(filePath, 'Content for metadata test.', 'utf8');
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    const payloadBefore = await vectorStore.getPayload(id);
-    const hashBefore = payloadBefore!['content_hash'];
-
-    await processor.processMetadataUpdate(filePath, {
-      title: 'Test Document',
-      labels: ['test'],
-    });
-
-    const payloadAfter = await vectorStore.getPayload(id);
-    // content_hash unchanged (no re-embed)
-    expect(payloadAfter!['content_hash']).toBe(hashBefore);
-    // metadata fields present
-    expect(payloadAfter!['title']).toBe('Test Document');
-    expect(payloadAfter!['labels']).toEqual(['test']);
-  });
-});
-
-describe('API endpoints', () => {
-  it('POST /rebuild-metadata should write meta files from Qdrant payloads', async () => {
-    const filePath = join(getWatchDir(), 'rebuild.txt');
-    await writeFile(filePath, 'Rebuild metadata content', 'utf8');
-    await processor.processFile(filePath);
-    await processor.processMetadataUpdate(filePath, { title: 'Rebuilt Title' });
-
-    const stateDir = config.stateDir ?? '.jeeves-metadata';
-    const server = createApiServer({
-      processor,
-      vectorStore,
-      embeddingProvider,
-      queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
-      config,
-      logger,
-      issuesManager: new IssuesManager(stateDir, logger),
-      valuesManager: new ValuesManager(stateDir, logger),
-      enrichmentStore,
-      configPath: '',
-    });
-
-    const res = await server.inject({
-      method: 'POST',
-      url: '/rebuild-metadata',
-    });
-    expect(res.statusCode).toBe(200);
-
-    const meta = enrichmentStore.get(filePath);
-    expect(meta).not.toBeNull();
-    expect(meta!['title']).toBe('Rebuilt Title');
-  });
-
-  it('POST /reindex with scope:rules should start reindex asynchronously', async () => {
-    const stateDir = config.stateDir ?? '.jeeves-metadata';
-    const server = createApiServer({
-      processor,
-      vectorStore,
-      embeddingProvider,
-      queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
-      config,
-      logger,
-      issuesManager: new IssuesManager(stateDir, logger),
-      valuesManager: new ValuesManager(stateDir, logger),
-      configPath: '',
-    });
-
-    const res = await server.inject({
-      method: 'POST',
-      url: '/reindex',
-      payload: { scope: 'rules' },
-    });
-    expect(res.statusCode).toBe(200);
-
-    const body = JSON.parse(res.body) as { status: string; scope: string };
-    expect(body.status).toBe('started');
-    expect(body.scope).toBe('rules');
-  });
-});
-
-describe('Rules engine', () => {
-  it('should apply inferred metadata from rules', async () => {
-    const watchDir = getWatchDir();
-    const filePath = join(watchDir, 'meetings', 'notes.md');
-    const { mkdir } = await import('node:fs/promises');
-    await mkdir(join(watchDir, 'meetings'), { recursive: true });
-    await writeFile(
-      filePath,
-      '# Meeting Notes\nDiscussed project plans.',
-      'utf8',
+  beforeAll(async () => {
+    vectorStore = new VectorStoreClient(
+      config.vectorStore,
+      embeddingProvider.dimensions,
     );
 
-    // Create processor with rules
-    const rulesConfig = {
-      ...config,
-      inferenceRules: [
-        {
-          name: 'meetings-rule',
-          description: 'Extract domain for meetings files',
-          match: {
-            properties: {
-              file: {
-                properties: {
-                  path: { type: 'string' as const, glob: '**/meetings/**' },
-                },
-              },
-            },
-          },
-          schema: [
-            {
-              properties: {
-                domain: { type: 'string', set: 'meetings' },
-              },
-            },
-          ],
-        },
-      ],
+    // Use raw Qdrant HTTP to ensure clean collection
+    const url = config.vectorStore.url;
+    const collectionName = config.vectorStore.collectionName;
+    try {
+      await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
+    } catch {
+      // ignore
+    }
+    await vectorStore.ensureCollection();
+
+    const compiledRules = compileRules(config.inferenceRules ?? []);
+
+    const stateDir = config.stateDir ?? '.jeeves-metadata';
+    enrichmentStore = new EnrichmentStore(stateDir);
+
+    const processorConfig = {
+      chunkSize: config.embedding.chunkSize,
+      chunkOverlap: config.embedding.chunkOverlap,
+      maps: config.maps,
     };
 
-    const compiledRules = compileRules(rulesConfig.inferenceRules);
-    const rulesProcessorConfig = {
-      chunkSize: rulesConfig.embedding.chunkSize,
-      chunkOverlap: rulesConfig.embedding.chunkOverlap,
-      maps: rulesConfig.maps,
-    };
-    const rulesProcessor = new DocumentProcessor({
-      config: rulesProcessorConfig,
+    processor = new DocumentProcessor({
+      config: processorConfig,
       embeddingProvider,
       vectorStore,
       compiledRules,
       logger,
-    });
-
-    await rulesProcessor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    const payload = await vectorStore.getPayload(id);
-    expect(payload).not.toBeNull();
-    expect(payload!['domain']).toBe('meetings');
-  });
-});
-
-describe('Full document lifecycle', () => {
-  it('should handle complete add/update/delete cycle', async () => {
-    const filePath = join(getWatchDir(), 'lifecycle.txt');
-
-    // Step 1: Add file
-    await writeFile(filePath, 'Initial content for lifecycle test.', 'utf8');
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    let payload = await vectorStore.getPayload(id);
-    expect(payload).not.toBeNull();
-    expect(payload!['chunk_text']).toContain('Initial content');
-    const initialHash = payload!['content_hash'];
-
-    // Step 2: Update file
-    await writeFile(
-      filePath,
-      'Updated content that is completely different.',
-      'utf8',
-    );
-    await processor.processFile(filePath);
-
-    payload = await vectorStore.getPayload(id);
-    expect(payload).not.toBeNull();
-    expect(payload!['chunk_text']).toContain('Updated content');
-    expect(payload!['content_hash']).not.toBe(initialHash);
-
-    // Step 3: Delete file
-    await processor.deleteFile(filePath);
-
-    payload = await vectorStore.getPayload(id);
-    expect(payload).toBeNull();
-  });
-});
-
-describe('Metadata enrichment via API', () => {
-  it('should enrich metadata via POST /metadata', async () => {
-    const filePath = join(getWatchDir(), 'enrich-api.txt');
-    await writeFile(filePath, 'Content for API enrichment test.', 'utf8');
-    await processor.processFile(filePath);
-
-    const stateDir = config.stateDir ?? '.jeeves-metadata';
-    const server = createApiServer({
-      processor,
-      vectorStore,
-      embeddingProvider,
-      queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
-      config,
-      logger,
-      issuesManager: new IssuesManager(stateDir, logger),
-      valuesManager: new ValuesManager(stateDir, logger),
       enrichmentStore,
-      configPath: '',
     });
-
-    // Enrich via API
-    const res = await server.inject({
-      method: 'POST',
-      url: '/metadata',
-      payload: {
-        path: filePath,
-        metadata: { category: 'documentation', priority: 'high' },
-      },
-    });
-
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body) as { ok: boolean };
-    expect(body.ok).toBe(true);
-
-    // Verify metadata in Qdrant
-    const id = pointId(filePath, 0);
-    const payload = await vectorStore.getPayload(id);
-    expect(payload).not.toBeNull();
-    expect(payload!['category']).toBe('documentation');
-    expect(payload!['priority']).toBe('high');
-  });
-});
-
-describe('File move', () => {
-  it('should move points to new path without re-embedding', async () => {
-    const filePath = join(getWatchDir(), 'move-source.txt');
-    const newPath = join(getWatchDir(), 'move-dest.txt');
-    await writeFile(filePath, 'Content for move test document.', 'utf8');
-
-    await processor.processFile(filePath);
-
-    const oldId = pointId(filePath, 0);
-    const oldPayload = await vectorStore.getPayload(oldId);
-    expect(oldPayload).not.toBeNull();
-    const oldHash = oldPayload!['content_hash'];
-
-    // Read old point with vectors to compare after move
-    const oldPoints = await vectorStore.getPointsWithVectors([oldId]);
-    expect(oldPoints).toHaveLength(1);
-    const oldVector = oldPoints[0].vector;
-
-    // Write file at new path (same content) for buildMetadataWithRules
-    await writeFile(newPath, 'Content for move test document.', 'utf8');
-
-    await processor.moveFile(filePath, newPath);
-
-    // Old point should be gone
-    const oldAfterMove = await vectorStore.getPayload(oldId);
-    expect(oldAfterMove).toBeNull();
-
-    // New point should exist with same vector
-    const newId = pointId(newPath, 0);
-    const newPayload = await vectorStore.getPayload(newId);
-    expect(newPayload).not.toBeNull();
-    expect(newPayload!['file_path']).toBe(newPath.replace(/\\/g, '/'));
-    expect(newPayload!['content_hash']).toBe(oldHash);
-
-    // Vector should be identical (no re-embedding)
-    const newPoints = await vectorStore.getPointsWithVectors([newId]);
-    expect(newPoints).toHaveLength(1);
-    expect(newPoints[0].vector).toEqual(oldVector);
   });
 
-  it('should migrate enrichment on move', async () => {
-    const filePath = join(getWatchDir(), 'move-enriched.txt');
-    const newPath = join(getWatchDir(), 'move-enriched-dest.txt');
-    await writeFile(filePath, 'Enriched content for move.', 'utf8');
-
-    await processor.processFile(filePath);
-
-    // Add enrichment
-    enrichmentStore.set(filePath, { category: 'important', tags: ['review'] });
-
-    // Write file at new path for buildMetadataWithRules
-    await writeFile(newPath, 'Enriched content for move.', 'utf8');
-
-    await processor.moveFile(filePath, newPath);
-
-    // Enrichment should be at new path
-    const movedEnrichment = enrichmentStore.get(newPath);
-    expect(movedEnrichment).not.toBeNull();
-    expect(movedEnrichment!['category']).toBe('important');
-    expect(movedEnrichment!['tags']).toEqual(['review']);
-
-    // Old path enrichment should be gone
-    expect(enrichmentStore.get(filePath)).toBeNull();
+  afterAll(async () => {
+    enrichmentStore.close();
+    const url = config.vectorStore.url;
+    const collectionName = config.vectorStore.collectionName;
+    try {
+      await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
+    } catch {
+      // ignore
+    }
+    await cleanupTestDirs();
   });
 
-  it('should preserve enrichments through full reindex', async () => {
-    const filePath = join(getWatchDir(), 'persist.txt');
-    await writeFile(filePath, 'Content that gets enriched.', 'utf8');
-
-    await processor.processFile(filePath);
-
-    const id = pointId(filePath, 0);
-    const payloadBefore = await vectorStore.getPayload(id);
-    expect(payloadBefore).not.toBeNull();
-
-    // Enrich the file via the store
-    enrichmentStore.set(filePath, { resonant: true });
-
-    // Simulate full reindex: modify file content to force re-embed
-    // (a real full reindex calls processFile on every file; the content
-    // hash check skips unchanged files, so we change the content)
-    await writeFile(
-      filePath,
-      'Content that gets enriched — updated for reindex.',
-      'utf8',
-    );
-    await processor.processFile(filePath);
-
-    const payload = await vectorStore.getPayload(id);
-    expect(payload).not.toBeNull();
-    // Enrichment should have been merged back in from SQLite
-    expect(payload!['resonant']).toBe(true);
+  beforeEach(async () => {
+    await setupTestDirs();
   });
-});
 
-describe('Search endpoint', () => {
-  it('should return relevant results from POST /search', async () => {
-    const filePath1 = join(getWatchDir(), 'search-doc1.txt');
-    const filePath2 = join(getWatchDir(), 'search-doc2.txt');
+  afterEach(async () => {
+    // Clear all points from collection
+    const url = config.vectorStore.url;
+    const collectionName = config.vectorStore.collectionName;
+    try {
+      await fetch(`${url}/collections/${collectionName}`, { method: 'DELETE' });
+    } catch {
+      // ignore
+    }
+    await vectorStore.ensureCollection();
+    await cleanupWatchedDir();
+  });
 
-    await writeFile(
-      filePath1,
-      'This document is about machine learning algorithms.',
-      'utf8',
-    );
-    await writeFile(
-      filePath2,
-      'This document discusses natural language processing.',
-      'utf8',
-    );
+  describe('File add', () => {
+    it('should index a new file with correct payload fields', async () => {
+      const filePath = join(getWatchDir(), 'test.txt');
+      await writeFile(
+        filePath,
+        'Hello world, this is a test document.',
+        'utf8',
+      );
 
-    await processor.processFile(filePath1);
-    await processor.processFile(filePath2);
+      await processor.processFile(filePath);
 
-    const stateDir = config.stateDir ?? '.jeeves-metadata';
-    const server = createApiServer({
-      processor,
-      vectorStore,
-      embeddingProvider,
-      queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
-      config,
-      logger,
-      issuesManager: new IssuesManager(stateDir, logger),
-      valuesManager: new ValuesManager(stateDir, logger),
-      configPath: '',
+      const id = pointId(filePath, 0);
+      const payload = await vectorStore.getPayload(id);
+
+      expect(payload).not.toBeNull();
+      expect(payload!['file_path']).toBe(filePath.replace(/\\/g, '/'));
+      expect(payload!['chunk_index']).toBe(0);
+      expect(payload!['content_hash']).toBeTypeOf('string');
+      expect(payload!['chunk_text']).toContain('Hello world');
+    });
+  });
+
+  describe('File update', () => {
+    it('should re-embed when content changes', async () => {
+      const filePath = join(getWatchDir(), 'update.txt');
+      await writeFile(filePath, 'Original content here.', 'utf8');
+      await processor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      const payload1 = await vectorStore.getPayload(id);
+      const hash1 = payload1!['content_hash'];
+
+      await writeFile(filePath, 'Updated content that is different.', 'utf8');
+      await processor.processFile(filePath);
+
+      const payload2 = await vectorStore.getPayload(id);
+      expect(payload2!['content_hash']).not.toBe(hash1);
+      expect(payload2!['chunk_text']).toContain('Updated content');
     });
 
-    // Search for "machine learning"
-    const res = await server.inject({
-      method: 'POST',
-      url: '/search',
-      payload: { query: 'machine learning', limit: 5 },
+    it('should skip re-embedding when content is unchanged', async () => {
+      const filePath = join(getWatchDir(), 'same.txt');
+      await writeFile(filePath, 'Same content.', 'utf8');
+      await processor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      const payload1 = await vectorStore.getPayload(id);
+
+      // Process again — should skip (content hash matches)
+      await processor.processFile(filePath);
+
+      const payload2 = await vectorStore.getPayload(id);
+      expect(payload2!['content_hash']).toBe(payload1!['content_hash']);
+    });
+  });
+
+  describe('File delete', () => {
+    it('should remove chunks from Qdrant', async () => {
+      const filePath = join(getWatchDir(), 'delete-me.txt');
+      await writeFile(filePath, 'Content to be deleted.', 'utf8');
+      await processor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      expect(await vectorStore.getPayload(id)).not.toBeNull();
+
+      await processor.deleteFile(filePath);
+      expect(await vectorStore.getPayload(id)).toBeNull();
+    });
+  });
+
+  describe('Metadata update', () => {
+    it('should update Qdrant payloads without re-embedding', async () => {
+      const filePath = join(getWatchDir(), 'meta.txt');
+      await writeFile(filePath, 'Content for metadata test.', 'utf8');
+      await processor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      const payloadBefore = await vectorStore.getPayload(id);
+      const hashBefore = payloadBefore!['content_hash'];
+
+      await processor.processMetadataUpdate(filePath, {
+        title: 'Test Document',
+        labels: ['test'],
+      });
+
+      const payloadAfter = await vectorStore.getPayload(id);
+      // content_hash unchanged (no re-embed)
+      expect(payloadAfter!['content_hash']).toBe(hashBefore);
+      // metadata fields present
+      expect(payloadAfter!['title']).toBe('Test Document');
+      expect(payloadAfter!['labels']).toEqual(['test']);
+    });
+  });
+
+  describe('API endpoints', () => {
+    it('POST /rebuild-metadata should write meta files from Qdrant payloads', async () => {
+      const filePath = join(getWatchDir(), 'rebuild.txt');
+      await writeFile(filePath, 'Rebuild metadata content', 'utf8');
+      await processor.processFile(filePath);
+      await processor.processMetadataUpdate(filePath, {
+        title: 'Rebuilt Title',
+      });
+
+      const stateDir = config.stateDir ?? '.jeeves-metadata';
+      const server = createApiServer({
+        processor,
+        vectorStore,
+        embeddingProvider,
+        queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
+        config,
+        logger,
+        issuesManager: new IssuesManager(stateDir, logger),
+        valuesManager: new ValuesManager(stateDir, logger),
+        enrichmentStore,
+        configPath: '',
+      });
+
+      const res = await server.inject({
+        method: 'POST',
+        url: '/rebuild-metadata',
+      });
+      expect(res.statusCode).toBe(200);
+
+      const meta = enrichmentStore.get(filePath);
+      expect(meta).not.toBeNull();
+      expect(meta!['title']).toBe('Rebuilt Title');
     });
 
-    expect(res.statusCode).toBe(200);
-    const results = JSON.parse(res.body) as Array<{
-      id: string;
-      score: number;
-      payload: Record<string, unknown>;
-    }>;
+    it('POST /reindex with scope:rules should start reindex asynchronously', async () => {
+      const stateDir = config.stateDir ?? '.jeeves-metadata';
+      const server = createApiServer({
+        processor,
+        vectorStore,
+        embeddingProvider,
+        queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
+        config,
+        logger,
+        issuesManager: new IssuesManager(stateDir, logger),
+        valuesManager: new ValuesManager(stateDir, logger),
+        configPath: '',
+      });
 
-    expect(results).toBeInstanceOf(Array);
-    expect(results.length).toBeGreaterThan(0);
+      const res = await server.inject({
+        method: 'POST',
+        url: '/reindex',
+        payload: { scope: 'rules' },
+      });
+      expect(res.statusCode).toBe(200);
 
-    // With mock embeddings, we can't guarantee order, but we should get results
-    const texts = results.map((r) => r.payload['chunk_text']);
-    expect(
-      texts.some((t) => typeof t === 'string' && t.includes('machine')),
-    ).toBe(true);
+      const body = JSON.parse(res.body) as { status: string; scope: string };
+      expect(body.status).toBe('started');
+      expect(body.scope).toBe('rules');
+    });
+  });
+
+  describe('Rules engine', () => {
+    it('should apply inferred metadata from rules', async () => {
+      const watchDir = getWatchDir();
+      const filePath = join(watchDir, 'meetings', 'notes.md');
+      const { mkdir } = await import('node:fs/promises');
+      await mkdir(join(watchDir, 'meetings'), { recursive: true });
+      await writeFile(
+        filePath,
+        '# Meeting Notes\nDiscussed project plans.',
+        'utf8',
+      );
+
+      // Create processor with rules
+      const rulesConfig = {
+        ...config,
+        inferenceRules: [
+          {
+            name: 'meetings-rule',
+            description: 'Extract domain for meetings files',
+            match: {
+              properties: {
+                file: {
+                  properties: {
+                    path: { type: 'string' as const, glob: '**/meetings/**' },
+                  },
+                },
+              },
+            },
+            schema: [
+              {
+                properties: {
+                  domain: { type: 'string', set: 'meetings' },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const compiledRules = compileRules(rulesConfig.inferenceRules);
+      const rulesProcessorConfig = {
+        chunkSize: rulesConfig.embedding.chunkSize,
+        chunkOverlap: rulesConfig.embedding.chunkOverlap,
+        maps: rulesConfig.maps,
+      };
+      const rulesProcessor = new DocumentProcessor({
+        config: rulesProcessorConfig,
+        embeddingProvider,
+        vectorStore,
+        compiledRules,
+        logger,
+      });
+
+      await rulesProcessor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      const payload = await vectorStore.getPayload(id);
+      expect(payload).not.toBeNull();
+      expect(payload!['domain']).toBe('meetings');
+    });
+  });
+
+  describe('Full document lifecycle', () => {
+    it('should handle complete add/update/delete cycle', async () => {
+      const filePath = join(getWatchDir(), 'lifecycle.txt');
+
+      // Step 1: Add file
+      await writeFile(filePath, 'Initial content for lifecycle test.', 'utf8');
+      await processor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      let payload = await vectorStore.getPayload(id);
+      expect(payload).not.toBeNull();
+      expect(payload!['chunk_text']).toContain('Initial content');
+      const initialHash = payload!['content_hash'];
+
+      // Step 2: Update file
+      await writeFile(
+        filePath,
+        'Updated content that is completely different.',
+        'utf8',
+      );
+      await processor.processFile(filePath);
+
+      payload = await vectorStore.getPayload(id);
+      expect(payload).not.toBeNull();
+      expect(payload!['chunk_text']).toContain('Updated content');
+      expect(payload!['content_hash']).not.toBe(initialHash);
+
+      // Step 3: Delete file
+      await processor.deleteFile(filePath);
+
+      payload = await vectorStore.getPayload(id);
+      expect(payload).toBeNull();
+    });
+  });
+
+  describe('Metadata enrichment via API', () => {
+    it('should enrich metadata via POST /metadata', async () => {
+      const filePath = join(getWatchDir(), 'enrich-api.txt');
+      await writeFile(filePath, 'Content for API enrichment test.', 'utf8');
+      await processor.processFile(filePath);
+
+      const stateDir = config.stateDir ?? '.jeeves-metadata';
+      const server = createApiServer({
+        processor,
+        vectorStore,
+        embeddingProvider,
+        queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
+        config,
+        logger,
+        issuesManager: new IssuesManager(stateDir, logger),
+        valuesManager: new ValuesManager(stateDir, logger),
+        enrichmentStore,
+        configPath: '',
+      });
+
+      // Enrich via API
+      const res = await server.inject({
+        method: 'POST',
+        url: '/metadata',
+        payload: {
+          path: filePath,
+          metadata: { category: 'documentation', priority: 'high' },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as { ok: boolean };
+      expect(body.ok).toBe(true);
+
+      // Verify metadata in Qdrant
+      const id = pointId(filePath, 0);
+      const payload = await vectorStore.getPayload(id);
+      expect(payload).not.toBeNull();
+      expect(payload!['category']).toBe('documentation');
+      expect(payload!['priority']).toBe('high');
+    });
+  });
+
+  describe('File move', () => {
+    it('should move points to new path without re-embedding', async () => {
+      const filePath = join(getWatchDir(), 'move-source.txt');
+      const newPath = join(getWatchDir(), 'move-dest.txt');
+      await writeFile(filePath, 'Content for move test document.', 'utf8');
+
+      await processor.processFile(filePath);
+
+      const oldId = pointId(filePath, 0);
+      const oldPayload = await vectorStore.getPayload(oldId);
+      expect(oldPayload).not.toBeNull();
+      const oldHash = oldPayload!['content_hash'];
+
+      // Read old point with vectors to compare after move
+      const oldPoints = await vectorStore.getPointsWithVectors([oldId]);
+      expect(oldPoints).toHaveLength(1);
+      const oldVector = oldPoints[0].vector;
+
+      // Write file at new path (same content) for buildMetadataWithRules
+      await writeFile(newPath, 'Content for move test document.', 'utf8');
+
+      await processor.moveFile(filePath, newPath);
+
+      // Old point should be gone
+      const oldAfterMove = await vectorStore.getPayload(oldId);
+      expect(oldAfterMove).toBeNull();
+
+      // New point should exist with same vector
+      const newId = pointId(newPath, 0);
+      const newPayload = await vectorStore.getPayload(newId);
+      expect(newPayload).not.toBeNull();
+      expect(newPayload!['file_path']).toBe(newPath.replace(/\\/g, '/'));
+      expect(newPayload!['content_hash']).toBe(oldHash);
+
+      // Vector should be identical (no re-embedding)
+      const newPoints = await vectorStore.getPointsWithVectors([newId]);
+      expect(newPoints).toHaveLength(1);
+      expect(newPoints[0].vector).toEqual(oldVector);
+    });
+
+    it('should migrate enrichment on move', async () => {
+      const filePath = join(getWatchDir(), 'move-enriched.txt');
+      const newPath = join(getWatchDir(), 'move-enriched-dest.txt');
+      await writeFile(filePath, 'Enriched content for move.', 'utf8');
+
+      await processor.processFile(filePath);
+
+      // Add enrichment
+      enrichmentStore.set(filePath, {
+        category: 'important',
+        tags: ['review'],
+      });
+
+      // Write file at new path for buildMetadataWithRules
+      await writeFile(newPath, 'Enriched content for move.', 'utf8');
+
+      await processor.moveFile(filePath, newPath);
+
+      // Enrichment should be at new path
+      const movedEnrichment = enrichmentStore.get(newPath);
+      expect(movedEnrichment).not.toBeNull();
+      expect(movedEnrichment!['category']).toBe('important');
+      expect(movedEnrichment!['tags']).toEqual(['review']);
+
+      // Old path enrichment should be gone
+      expect(enrichmentStore.get(filePath)).toBeNull();
+    });
+
+    it('should preserve enrichments through full reindex', async () => {
+      const filePath = join(getWatchDir(), 'persist.txt');
+      await writeFile(filePath, 'Content that gets enriched.', 'utf8');
+
+      await processor.processFile(filePath);
+
+      const id = pointId(filePath, 0);
+      const payloadBefore = await vectorStore.getPayload(id);
+      expect(payloadBefore).not.toBeNull();
+
+      // Enrich the file via the store
+      enrichmentStore.set(filePath, { resonant: true });
+
+      // Simulate full reindex: modify file content to force re-embed
+      // (a real full reindex calls processFile on every file; the content
+      // hash check skips unchanged files, so we change the content)
+      await writeFile(
+        filePath,
+        'Content that gets enriched — updated for reindex.',
+        'utf8',
+      );
+      await processor.processFile(filePath);
+
+      const payload = await vectorStore.getPayload(id);
+      expect(payload).not.toBeNull();
+      // Enrichment should have been merged back in from SQLite
+      expect(payload!['resonant']).toBe(true);
+    });
+  });
+
+  describe('Search endpoint', () => {
+    it('should return relevant results from POST /search', async () => {
+      const filePath1 = join(getWatchDir(), 'search-doc1.txt');
+      const filePath2 = join(getWatchDir(), 'search-doc2.txt');
+
+      await writeFile(
+        filePath1,
+        'This document is about machine learning algorithms.',
+        'utf8',
+      );
+      await writeFile(
+        filePath2,
+        'This document discusses natural language processing.',
+        'utf8',
+      );
+
+      await processor.processFile(filePath1);
+      await processor.processFile(filePath2);
+
+      const stateDir = config.stateDir ?? '.jeeves-metadata';
+      const server = createApiServer({
+        processor,
+        vectorStore,
+        embeddingProvider,
+        queue: new EventQueue({ debounceMs: 0, concurrency: 1 }),
+        config,
+        logger,
+        issuesManager: new IssuesManager(stateDir, logger),
+        valuesManager: new ValuesManager(stateDir, logger),
+        configPath: '',
+      });
+
+      // Search for "machine learning"
+      const res = await server.inject({
+        method: 'POST',
+        url: '/search',
+        payload: { query: 'machine learning', limit: 5 },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const results = JSON.parse(res.body) as Array<{
+        id: string;
+        score: number;
+        payload: Record<string, unknown>;
+      }>;
+
+      expect(results).toBeInstanceOf(Array);
+      expect(results.length).toBeGreaterThan(0);
+
+      // With mock embeddings, we can't guarantee order, but we should get results
+      const texts = results.map((r) => r.payload['chunk_text']);
+      expect(
+        texts.some((t) => typeof t === 'string' && t.includes('machine')),
+      ).toBe(true);
+    });
   });
 });

--- a/packages/service/vitest.config.ts
+++ b/packages/service/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    globalSetup: ['./src/test/globalSetup.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/.rollup.cache/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Problem

Two categories of Linux CI failures:

### 1. Path handling (unit test)

getConfigDir test used a hardcoded Windows path \C:\configs\config.json\. On Linux, \path.dirname('C:\configs\config.json')\ returns \.\ because Linux \path\ doesn't understand Windows backslash paths.

### 2. Integration tests (Qdrant unavailable)

Integration tests fail with \TypeError: fetch failed\ in CI because Qdrant isn't available in the Linux CI environment.

## Fix

### Path test fix
- Replaced \C:\\configs\\jeeves.yaml\ with \/configs/jeeves.yaml\ in \initialization.test.ts\ — the test just validates that dirname extraction works, not Windows-specific behaviour.

### Integration test skip
- Added \src/test/globalSetup.ts\: probes Qdrant \/healthz\ before tests run and sets \QDRANT_AVAILABLE=true/false\
- Registered \globalSetup\ in \itest.config.ts\
- Wrapped all tests in \integration.test.ts\ and \gitignore-integration.test.ts\ in \describe.skipIf(process.env['QDRANT_AVAILABLE'] !== 'true')\
- Also exported \isQdrantAvailable()\ from \helpers.ts\ for future use

Result: unit tests always run on all platforms; integration tests skip gracefully in CI when Qdrant is unavailable.