### PR TITLE
feat: integrate core 0.4.6 - init before descriptor.run()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.4.5.tgz",
-      "integrity": "sha512-jkq4vcBnx6dkbYFcHcfaq362fYriyr9+IQTlImn2h54NzfODfXxBukwt5o70Wfu4vo5BhrlQp0H2zkCTRQtE0Q==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.4.6.tgz",
+      "integrity": "sha512-GVxk4zTO48H56x1OTU1ZKSQF/3KBygSIGhrjHIzCFdFK7RvcHvRwo7aP2XIiV1vR8k1h+1IiOozVruoB94CWmg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.3",
@@ -11878,10 +11878,10 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-watcher-openclaw",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.4.4"
+        "@karmaniverous/jeeves": "^0.4.6"
       },
       "bin": {
         "jeeves-watcher-openclaw": "dist/cli.js"
@@ -12125,11 +12125,11 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-watcher",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "@karmaniverous/jeeves": "^0.4.4",
+        "@karmaniverous/jeeves": "^0.4.6",
         "@karmaniverous/jsonmap": "^2.1.1",
         "@langchain/textsplitters": "*",
         "@qdrant/js-client-rest": "*",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -57,7 +57,7 @@
     "hideCredit": true
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.4.4"
+    "@karmaniverous/jeeves": "^0.4.6"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.59.1",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
-    "@karmaniverous/jeeves": "^0.4.4",
+    "@karmaniverous/jeeves": "^0.4.6",
     "@karmaniverous/jsonmap": "^2.1.1",
     "@langchain/textsplitters": "*",
     "@qdrant/js-client-rest": "*",


### PR DESCRIPTION
## Summary

Integrates karmaniverous/jeeves#54 by bumping core to 0.4.6.

## Changes

- bump `@karmaniverous/jeeves` to `0.4.6` in service and OpenClaw plugin workspaces
- adopt core fix where `createServiceCli` calls `init()` before `descriptor.run()`
- unblock watcher startup via `createServiceCli start` command

## Validation

- `npm run lint -- --no-color`
- `npm run typecheck`
- `npm test`
- `npm run knip`
