### PR TITLE
fix: pin jeeves-watcher-core dependency to ^0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12084,7 +12084,7 @@
     },
     "packages/core": {
       "name": "@karmaniverous/jeeves-watcher-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
         "@karmaniverous/jsonmap": "^2.1.1",
@@ -12110,11 +12110,11 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-watcher-openclaw",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-watcher-core": "*"
+        "@karmaniverous/jeeves-watcher-core": "^0.1.1"
       },
       "bin": {
         "jeeves-watcher-openclaw": "dist/cli.js"
@@ -12138,12 +12138,12 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-watcher",
-      "version": "0.17.8",
+      "version": "0.17.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-watcher-core": "*",
+        "@karmaniverous/jeeves-watcher-core": "^0.1.1",
         "@karmaniverous/jsonmap": "^2.1.1",
         "@langchain/textsplitters": "*",
         "@qdrant/js-client-rest": "*",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -111,6 +111,6 @@
   },
   "dependencies": {
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-watcher-core": "*"
+    "@karmaniverous/jeeves-watcher-core": "^0.1.1"
   }
 }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-watcher-core": "*",
+    "@karmaniverous/jeeves-watcher-core": "^0.1.1",
     "@karmaniverous/jsonmap": "^2.1.1",
     "@langchain/textsplitters": "*",
     "@qdrant/js-client-rest": "*",


### PR DESCRIPTION
Pin core dependency from * to ^0.1.1