### PR TITLE
[204] fix(openclaw): externalize @karmaniverous/jeeves in rollup config

### DIFF
--- a/packages/openclaw/rollup.config.ts
+++ b/packages/openclaw/rollup.config.ts
@@ -2,9 +2,9 @@
  * Rollup configuration for the OpenClaw plugin package.
  * Two entry points: plugin (ESM + declarations) and CLI (ESM executable).
  *
- * `@karmaniverous/jeeves` is BUNDLED into the plugin output — the plugin
- * runs in OpenClaw's extensions directory where node_modules is not
- * reliably available. All node: builtins are externalized.
+ * `@karmaniverous/jeeves` is externalized — the plugin installer copies
+ * the jeeves core lib into the extensions directory alongside the plugin
+ * output, so it is always resolvable at runtime.
  *
  * @module rollup.config
  */
@@ -15,10 +15,12 @@ import resolve from '@rollup/plugin-node-resolve';
 import typescriptPlugin from '@rollup/plugin-typescript';
 import type { RollupOptions } from 'rollup';
 
+const external: (string | RegExp)[] = [/^node:/, '@karmaniverous/jeeves'];
+
 const pluginConfig: RollupOptions = {
   input: 'src/index.ts',
   output: { dir: 'dist', format: 'esm' },
-  external: [/^node:/],
+  external,
   plugins: [
     resolve({ preferBuiltins: true }),
     commonjs(),
@@ -37,7 +39,7 @@ const pluginConfig: RollupOptions = {
 
 const cliConfig: RollupOptions = {
   input: 'src/cli.ts',
-  external: [/^node:/],
+  external,
   output: {
     file: 'dist/cli.js',
     format: 'esm',


### PR DESCRIPTION
## Summary

Externalizes @karmaniverous/jeeves in the openclaw package rollup config (both plugin and CLI builds). Previously it was bundled into the output; now it's treated as an external dependency — the plugin installer copies the jeeves core lib into the extensions directory, so it's always resolvable at runtime.

## Changes

- **packages/openclaw/rollup.config.ts**: Added @karmaniverous/jeeves to a shared external array used by both plugin and CLI configs. Updated the module JSDoc to reflect the new externalization strategy.

## Verification

- **Service package**: Already externalizes via Object.keys(pkg.dependencies) — confirmed @karmaniverous/jeeves is listed in service dependencies. No change needed.
- **Core package**: Already has explicit external array including @karmaniverous/jeeves. No change needed.
- Typecheck: ✅
- Lint: ✅
- Build: ✅ (verified import ... from '@karmaniverous/jeeves' appears in built output)
- Tests: ✅ (587/587 passed)

Closes #204