### PR TITLE
fix: VCS case-sensitive path matching on Windows + baseline commit

### DIFF
--- a/packages/service/src/app/index.ts
+++ b/packages/service/src/app/index.ts
@@ -189,7 +189,7 @@ export class JeevesWatcher {
 
     this.server = await this.startApiServer();
 
-    vcsCoordinator.start();
+    await vcsCoordinator.start();
     this.watcher.start();
     this.startConfigWatch();
 

--- a/packages/service/src/vcs/VcsCoordinator.test.ts
+++ b/packages/service/src/vcs/VcsCoordinator.test.ts
@@ -77,7 +77,7 @@ describe('VcsCoordinator', () => {
   it('routes file changes to the correct root manager', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Write files to both roots
     const fileA = join(resolve(rootA), 'a.txt');
@@ -105,7 +105,7 @@ describe('VcsCoordinator', () => {
   it('ignores files that do not match any root', async () => {
     const config = makeConfig([rootA]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // A file outside all roots — should be silently ignored
     coordinator.onFileChange('/nonexistent/path/file.txt', 'add');
@@ -123,7 +123,7 @@ describe('VcsCoordinator', () => {
     } as unknown as JeevesWatcherConfig;
 
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     const fileA = join(resolve(rootA), 'a.txt');
     await writeFile(fileA, 'content', 'utf8');
@@ -138,7 +138,7 @@ describe('VcsCoordinator', () => {
   it('handles unlink events by staging deletions', async () => {
     const config = makeConfig([rootA]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Create and commit a file first
     const filePath = join(resolve(rootA), 'to-remove.txt');
@@ -175,7 +175,7 @@ describe('VcsCoordinator', () => {
   it('stop flushes all pending changes', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Add files to both roots without flushing
     const fileA = join(resolve(rootA), 'pending-a.txt');

--- a/packages/service/src/vcs/VcsCoordinator.ts
+++ b/packages/service/src/vcs/VcsCoordinator.ts
@@ -16,7 +16,7 @@ import type { JeevesWatcherConfig } from '../config/types';
 import { normalizeSlashes } from '../util/normalizeSlashes';
 import { globRoot } from '../watcher/globToDir.js';
 import { CommitMessageGenerator } from './CommitMessageGenerator';
-import { findRootForPath } from './gitExec';
+import { findRootForPath, normalizePathCase } from './gitExec';
 import { resolveCommitMessageApiKey } from './resolveCommitMessageApiKey';
 import { VcsManager } from './VcsManager';
 
@@ -39,9 +39,10 @@ export class VcsCoordinator {
       if (!rootVcs) continue;
 
       const resolvedRoot = normalizeSlashes(resolve(globRoot(entry.path)));
+      const rootKey = normalizePathCase(resolvedRoot);
 
       // Deduplicate: skip if another glob already resolved to this root.
-      if (this.managers.has(resolvedRoot)) continue;
+      if (this.managers.has(rootKey)) continue;
       const mergedConfig: VcsConfig = {
         ...config.vcs,
         ...entry.vcs,
@@ -82,7 +83,7 @@ export class VcsCoordinator {
         remoteUrl,
         accessToken,
       );
-      this.managers.set(resolvedRoot, manager);
+      this.managers.set(rootKey, manager);
       this.roots.push(resolvedRoot);
     }
 
@@ -93,10 +94,12 @@ export class VcsCoordinator {
   /**
    * Start all VcsManager instances.
    */
-  start(): void {
+  async start(): Promise<void> {
+    const startPromises: Promise<void>[] = [];
     this.managers.forEach((manager) => {
-      manager.start();
+      startPromises.push(manager.start());
     });
+    await Promise.all(startPromises);
     this.logger.info(
       { rootCount: this.managers.size },
       'VcsCoordinator started',
@@ -144,7 +147,7 @@ export class VcsCoordinator {
    * Get the VcsManager for a specific root path.
    */
   getManager(root: string): VcsManager | undefined {
-    return this.managers.get(root);
+    return this.managers.get(normalizePathCase(root));
   }
 
   /**
@@ -163,6 +166,6 @@ export class VcsCoordinator {
    */
   findManagerForPath(normalizedPath: string): VcsManager | undefined {
     const root = findRootForPath(this.roots, normalizedPath);
-    return root ? this.managers.get(root) : undefined;
+    return root ? this.managers.get(normalizePathCase(root)) : undefined;
   }
 }

--- a/packages/service/src/vcs/VcsManager.test.ts
+++ b/packages/service/src/vcs/VcsManager.test.ts
@@ -70,7 +70,7 @@ describe('VcsManager instance', () => {
   describe('flush', () => {
     it('commits pending files to git', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'test.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -97,7 +97,7 @@ describe('VcsManager instance', () => {
       });
 
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const { stdout: before } = await execFileAsync(
         'git',
@@ -116,7 +116,7 @@ describe('VcsManager instance', () => {
 
     it('handles multiple files in a single commit', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       for (let i = 0; i < 5; i++) {
         const filePath = join(tempDir, `file${String(i)}.txt`);
@@ -138,7 +138,7 @@ describe('VcsManager instance', () => {
   describe('handleUnlink', () => {
     it('stages file deletion in pending set', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       // Create and commit a file first
       const filePath = join(tempDir, 'to-delete.txt');
@@ -175,7 +175,7 @@ describe('VcsManager instance', () => {
 
       const config = makeConfig({ commitDebounceMs: 5000 });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      manager.start();
+      await manager.start();
 
       // Mock flush to avoid real git operations with fake timers
       const flushSpy = vi.spyOn(manager, 'flush').mockResolvedValue(undefined);
@@ -209,7 +209,7 @@ describe('VcsManager instance', () => {
         commitDebounceMs: 60000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      manager.start();
+      await manager.start();
 
       for (let i = 0; i < 3; i++) {
         const filePath = join(tempDir, `file${String(i)}.txt`);
@@ -235,7 +235,7 @@ describe('VcsManager instance', () => {
         commitDebounceMs: 1000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      manager.start();
+      await manager.start();
 
       // Create 3 files — 2 should commit immediately, 1 starts new timer
       for (let i = 0; i < 3; i++) {
@@ -255,7 +255,7 @@ describe('VcsManager instance', () => {
   describe('stop', () => {
     it('flushes pending changes on stop', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'stop-test.txt');
       await writeFile(filePath, 'should be committed on stop', 'utf8');
@@ -273,7 +273,7 @@ describe('VcsManager instance', () => {
 
     it('ignores fileChanged calls after stop', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const file1 = join(tempDir, 'before-stop.txt');
       await writeFile(file1, 'before', 'utf8');
@@ -305,7 +305,7 @@ describe('VcsManager instance', () => {
       const warnSpy = vi.spyOn(logger, 'warn');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      manager.start();
+      await manager.start();
 
       // Create index.lock to simulate contention
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -339,7 +339,7 @@ describe('VcsManager instance', () => {
       const errorSpy = vi.spyOn(logger, 'error');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      manager.start();
+      await manager.start();
 
       // Create index.lock and keep it there
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -363,7 +363,7 @@ describe('VcsManager instance', () => {
       const warnSpy = vi.spyOn(logger, 'warn');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      manager.start();
+      await manager.start();
 
       // Create index.lock to force failure
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -398,7 +398,7 @@ describe('VcsManager instance', () => {
   describe('pendingReversions', () => {
     it('generates revert-prefixed commit message when reversion is pending', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'reverted.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -431,7 +431,7 @@ describe('VcsManager instance', () => {
 
     it('includes other changes count in revert message when mixed', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       // Create initial commit
       const file1 = join(tempDir, 'reverted.txt');
@@ -470,7 +470,7 @@ describe('VcsManager instance', () => {
 
     it('clears pending reversions after commit', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const file1 = join(tempDir, 'first.txt');
       await writeFile(file1, 'content', 'utf8');
@@ -516,7 +516,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'ai-test.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -547,7 +547,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'fallback.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -580,7 +580,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'error-fallback.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -613,7 +613,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'reverted-ai.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -658,7 +658,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'revert-fallback.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -687,6 +687,106 @@ describe('VcsManager instance', () => {
     });
   });
 
+  describe('baseline commit', () => {
+    it('creates a baseline commit for pre-existing files in an empty repo', async () => {
+      // Do NOT make any initial commits — the repo should be empty
+      const filePath = join(tempDir, 'pre-existing.txt');
+      await writeFile(filePath, 'already here', 'utf8');
+
+      const manager = new VcsManager(
+        tempDir,
+        makeConfig({ commitDebounceMs: 100 }),
+        silentLogger,
+      );
+      await manager.start();
+
+      // Wait for debounce + commit
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(1);
+      const { stdout } = await execFileAsync(
+        'git',
+        ['log', '--oneline', '-1'],
+        { cwd: tempDir },
+      );
+      expect(stdout).toContain('baseline: batch');
+      expect(stdout).toContain('1 files');
+    });
+
+    it('does not create baseline when repo already has commits', async () => {
+      // initRepo already ran in beforeEach; create and commit a file
+      const filePath = join(tempDir, 'existing.txt');
+      await writeFile(filePath, 'content', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: tempDir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], {
+        cwd: tempDir,
+      });
+
+      // Create another file that is untracked
+      const filePath2 = join(tempDir, 'untracked.txt');
+      await writeFile(filePath2, 'untracked', 'utf8');
+
+      const manager = new VcsManager(
+        tempDir,
+        makeConfig({ commitDebounceMs: 100 }),
+        silentLogger,
+      );
+      await manager.start();
+
+      // Flush should be a no-op — baseline should not have enqueued
+      await manager.flush();
+
+      // Should still be at 1 commit (the initial one)
+      expect(await commitCount(tempDir)).toBe(1);
+    });
+
+    it('uses normal commit messages after baseline is done', async () => {
+      // Start with pre-existing file, no commits
+      const filePath = join(tempDir, 'pre-existing.txt');
+      await writeFile(filePath, 'baseline content', 'utf8');
+
+      const manager = new VcsManager(
+        tempDir,
+        makeConfig({ commitDebounceMs: 100 }),
+        silentLogger,
+      );
+      await manager.start();
+      await manager.flush();
+
+      // Now add a second file — should use normal message
+      const filePath2 = join(tempDir, 'new-file.txt');
+      await writeFile(filePath2, 'new content', 'utf8');
+      manager.fileChanged(filePath2);
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(2);
+      const { stdout } = await execFileAsync(
+        'git',
+        ['log', '--oneline', '-1'],
+        { cwd: tempDir },
+      );
+      expect(stdout).toContain('watcher: batch');
+      expect(stdout).not.toContain('baseline');
+    });
+
+    it('handles empty repo with no untracked files', async () => {
+      const manager = new VcsManager(
+        tempDir,
+        makeConfig({ commitDebounceMs: 100 }),
+        silentLogger,
+      );
+      // tempDir has .gitignore from initRepo but no other untracked files
+      // (actually initRepo just does git init, so it might be empty)
+      await manager.start();
+      await manager.flush();
+
+      // Should have 0 or 1 commits depending on whether .gitignore exists
+      const count = await commitCount(tempDir);
+      // The initRepo creates .git but no .gitignore, so 0 untracked files
+      expect(count).toBeLessThanOrEqual(1);
+    });
+  });
+
   describe('remote push', () => {
     let bareRemote: string;
 
@@ -708,7 +808,7 @@ describe('VcsManager instance', () => {
         undefined,
         remoteUrl,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'push-test.txt');
       await writeFile(filePath, 'push content', 'utf8');
@@ -729,7 +829,7 @@ describe('VcsManager instance', () => {
 
     it('does nothing when no remote is configured', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'no-remote.txt');
       await writeFile(filePath, 'no remote', 'utf8');
@@ -752,7 +852,7 @@ describe('VcsManager instance', () => {
         undefined,
         'https://invalid.example.com/nonexistent/repo.git',
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'push-fail.txt');
       await writeFile(filePath, 'will fail push', 'utf8');
@@ -778,7 +878,7 @@ describe('VcsManager instance', () => {
         'https://github.com/test/repo.git',
         'tok/en@special',
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'encode-test.txt');
       await writeFile(filePath, 'content', 'utf8');
@@ -805,7 +905,7 @@ describe('VcsManager instance', () => {
         remoteUrl, // use plain path so push actually works
         'fake-token',
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'token-push.txt');
       await writeFile(filePath, 'token push content', 'utf8');

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -49,6 +49,7 @@ export class VcsManager {
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private commitInFlight: Promise<void> = Promise.resolve();
   private started = false;
+  private isBaseline = false;
   private _lastPushTime: string | null = null;
 
   constructor(
@@ -87,11 +88,61 @@ export class VcsManager {
 
   /**
    * Begin accepting file changes. Sets up the debounce mechanism.
+   * Enqueues a baseline commit for pre-existing files if the repo has no commits.
    */
-  start(): void {
+  async start(): Promise<void> {
     this.started = true;
     this.squashManager?.start();
     this.logger.info({ root: this.rootPath }, 'VcsManager started');
+
+    await this.enqueueBaselineIfNeeded();
+  }
+
+  /**
+   * If the repo has no commits, enumerate untracked files and feed them
+   * through fileChanged() to create a baseline commit.
+   */
+  private async enqueueBaselineIfNeeded(): Promise<void> {
+    try {
+      await execFileAsync('git', ['rev-parse', 'HEAD'], {
+        cwd: this.rootPath,
+      });
+      // HEAD exists — repo already has commits
+      return;
+    } catch {
+      // No commits yet — proceed with baseline
+    }
+
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['ls-files', '--others', '--exclude-standard'],
+        { cwd: this.rootPath },
+      );
+
+      const files = stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+
+      if (files.length === 0) return;
+
+      this.logger.info(
+        { root: this.rootPath, fileCount: files.length },
+        'Enqueuing baseline commit for pre-existing files',
+      );
+
+      this.isBaseline = true;
+      const absolutePaths = files.map((f) => this.rootPath + '/' + f);
+      for (const filePath of absolutePaths) {
+        this.fileChanged(filePath);
+      }
+    } catch (error) {
+      this.logger.warn(
+        { root: this.rootPath, err: normalizeError(error) },
+        'Failed to enumerate untracked files for baseline commit',
+      );
+    }
   }
 
   /**
@@ -227,6 +278,9 @@ export class VcsManager {
    */
   private buildTemplateMessage(fileCount: number): string {
     if (this.pendingReversions.length === 0) {
+      if (this.isBaseline) {
+        return `baseline: batch (${String(fileCount)} files)`;
+      }
       const timestamp = new Date().toISOString();
       return `watcher: batch ${timestamp} (${String(fileCount)} files)`;
     }
@@ -311,6 +365,7 @@ export class VcsManager {
               ? await this.buildCommitMessage(files)
               : this.buildTemplateMessage(files.length);
           this.pendingReversions.length = 0;
+          this.isBaseline = false;
 
           await execFileAsync('git', ['commit', '-m', message], {
             cwd: this.rootPath,

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -116,12 +116,12 @@ export class VcsManager {
     try {
       const { stdout } = await execFileAsync(
         'git',
-        ['ls-files', '--others', '--exclude-standard'],
+        ['ls-files', '--others', '--exclude-standard', '-z'],
         { cwd: this.rootPath },
       );
 
       const files = stdout
-        .split('\n')
+        .split('\0')
         .map((line) => line.trim())
         .filter((line) => line.length > 0);
 
@@ -360,12 +360,16 @@ export class VcsManager {
           });
 
           // Build message after staging so getStagedDiff can see the changes
+          // Skip AI for baselines and retries — use template directly
           const message =
-            attempt === 1
-              ? await this.buildCommitMessage(files)
-              : this.buildTemplateMessage(files.length);
+            this.isBaseline || attempt > 1
+              ? this.buildTemplateMessage(files.length)
+              : await this.buildCommitMessage(files);
           this.pendingReversions.length = 0;
-          this.isBaseline = false;
+          // Only clear baseline flag when all baseline files have been committed
+          if (this.pending.size === 0) {
+            this.isBaseline = false;
+          }
 
           await execFileAsync('git', ['commit', '-m', message], {
             cwd: this.rootPath,

--- a/packages/service/src/vcs/gitExec.test.ts
+++ b/packages/service/src/vcs/gitExec.test.ts
@@ -31,25 +31,22 @@ describe('findRootForPath', () => {
   });
 
   it('matches case-insensitively on Windows (drive letter mismatch)', () => {
-    if (process.platform !== 'win32') return;
     const roots = ['j:/domains/projects'];
-    expect(findRootForPath(roots, 'J:/domains/projects/file.txt')).toBe(
-      'j:/domains/projects',
-    );
+    expect(
+      findRootForPath(roots, 'J:/domains/projects/file.txt', 'win32'),
+    ).toBe('j:/domains/projects');
   });
 
   it('matches case-insensitively on Windows (root uppercase, path lowercase)', () => {
-    if (process.platform !== 'win32') return;
     const roots = ['J:/Domains/Projects'];
-    expect(findRootForPath(roots, 'j:/domains/projects/file.txt')).toBe(
-      'J:/Domains/Projects',
-    );
+    expect(
+      findRootForPath(roots, 'j:/domains/projects/file.txt', 'win32'),
+    ).toBe('J:/Domains/Projects');
   });
 
   it('matches case-insensitively on Windows (exact path equals root)', () => {
-    if (process.platform !== 'win32') return;
     const roots = ['j:/domains'];
-    expect(findRootForPath(roots, 'J:/domains')).toBe('j:/domains');
+    expect(findRootForPath(roots, 'J:/domains', 'win32')).toBe('j:/domains');
   });
 });
 

--- a/packages/service/src/vcs/gitExec.test.ts
+++ b/packages/service/src/vcs/gitExec.test.ts
@@ -29,6 +29,28 @@ describe('findRootForPath', () => {
   it('handles empty roots array', () => {
     expect(findRootForPath([], '/a/b/c')).toBeUndefined();
   });
+
+  it('matches case-insensitively on Windows (drive letter mismatch)', () => {
+    if (process.platform !== 'win32') return;
+    const roots = ['j:/domains/projects'];
+    expect(findRootForPath(roots, 'J:/domains/projects/file.txt')).toBe(
+      'j:/domains/projects',
+    );
+  });
+
+  it('matches case-insensitively on Windows (root uppercase, path lowercase)', () => {
+    if (process.platform !== 'win32') return;
+    const roots = ['J:/Domains/Projects'];
+    expect(findRootForPath(roots, 'j:/domains/projects/file.txt')).toBe(
+      'J:/Domains/Projects',
+    );
+  });
+
+  it('matches case-insensitively on Windows (exact path equals root)', () => {
+    if (process.platform !== 'win32') return;
+    const roots = ['j:/domains'];
+    expect(findRootForPath(roots, 'J:/domains')).toBe('j:/domains');
+  });
 });
 
 describe('isIndexLockError', () => {

--- a/packages/service/src/vcs/gitExec.ts
+++ b/packages/service/src/vcs/gitExec.ts
@@ -10,6 +10,17 @@ import { promisify } from 'node:util';
 export const execFileAsync = promisify(execFile);
 
 /**
+ * Normalize a path for case-insensitive comparison on Windows.
+ * On Windows, lowercases the entire path; on other platforms, returns as-is.
+ *
+ * @param p - The path string to normalize.
+ * @returns The normalized path.
+ */
+export function normalizePathCase(p: string): string {
+  return process.platform === 'win32' ? p.toLowerCase() : p;
+}
+
+/**
  * Find the longest-prefix-match root for a normalized path.
  * Roots must be sorted longest-first for correct nested matching.
  *
@@ -21,8 +32,13 @@ export function findRootForPath(
   roots: readonly string[],
   normalizedPath: string,
 ): string | undefined {
+  const comparePath = normalizePathCase(normalizedPath);
   for (const root of roots) {
-    if (normalizedPath === root || normalizedPath.startsWith(root + '/')) {
+    const compareRoot = normalizePathCase(root);
+    if (
+      comparePath === compareRoot ||
+      comparePath.startsWith(compareRoot + '/')
+    ) {
       return root;
     }
   }

--- a/packages/service/src/vcs/gitExec.ts
+++ b/packages/service/src/vcs/gitExec.ts
@@ -14,10 +14,14 @@ export const execFileAsync = promisify(execFile);
  * On Windows, lowercases the entire path; on other platforms, returns as-is.
  *
  * @param p - The path string to normalize.
+ * @param platform - The platform to check against (default: `process.platform`).
  * @returns The normalized path.
  */
-export function normalizePathCase(p: string): string {
-  return process.platform === 'win32' ? p.toLowerCase() : p;
+export function normalizePathCase(
+  p: string,
+  platform: string = process.platform,
+): string {
+  return platform === 'win32' ? p.toLowerCase() : p;
 }
 
 /**
@@ -26,15 +30,17 @@ export function normalizePathCase(p: string): string {
  *
  * @param roots - Root paths sorted longest-first.
  * @param normalizedPath - Normalized absolute path (forward slashes).
+ * @param platform - The platform to check against (default: `process.platform`).
  * @returns The matching root, or undefined.
  */
 export function findRootForPath(
   roots: readonly string[],
   normalizedPath: string,
+  platform: string = process.platform,
 ): string | undefined {
-  const comparePath = normalizePathCase(normalizedPath);
+  const comparePath = normalizePathCase(normalizedPath, platform);
   for (const root of roots) {
-    const compareRoot = normalizePathCase(root);
+    const compareRoot = normalizePathCase(root, platform);
     if (
       comparePath === compareRoot ||
       comparePath.startsWith(compareRoot + '/')

--- a/packages/service/src/vcs/index.ts
+++ b/packages/service/src/vcs/index.ts
@@ -4,7 +4,12 @@
  */
 
 export { CommitMessageGenerator } from './CommitMessageGenerator.js';
-export { execFileAsync, findRootForPath, isIndexLockError } from './gitExec.js';
+export {
+  execFileAsync,
+  findRootForPath,
+  isIndexLockError,
+  normalizePathCase,
+} from './gitExec.js';
 export { resolveCommitMessageApiKey } from './resolveCommitMessageApiKey.js';
 export {
   type ResolvedWatchRoot,

--- a/packages/service/src/vcs/resolveWatchRoot.ts
+++ b/packages/service/src/vcs/resolveWatchRoot.ts
@@ -6,7 +6,7 @@
 import { relative, resolve } from 'node:path';
 
 import { normalizeSlashes } from '../util/normalizeSlashes';
-import { findRootForPath } from './gitExec';
+import { findRootForPath, normalizePathCase } from './gitExec';
 import type { VcsCoordinator } from './VcsCoordinator';
 
 /** Result of resolving a path to its watch root. */
@@ -53,14 +53,19 @@ export function resolveWatchRootsForGlob(
   const roots = coordinator.getRoots();
   const results: ResolvedWatchRoot[] = [];
 
+  const compareGlob = normalizePathCase(normalizedGlob);
   for (const root of roots) {
-    if (normalizedGlob.startsWith(root + '/') || normalizedGlob === root) {
+    const compareRoot = normalizePathCase(root);
+    if (
+      compareGlob.startsWith(compareRoot + '/') ||
+      compareGlob === compareRoot
+    ) {
       // Glob is under this root
       results.push({
         root,
         relativePath: normalizeSlashes(relative(root, normalizedGlob)),
       });
-    } else if (root.startsWith(normalizedGlob.replace(/[*?[\]{}]/g, ''))) {
+    } else if (compareRoot.startsWith(compareGlob.replace(/[*?[\]{}]/g, ''))) {
       // Root is under the glob's base path — include with root-relative glob
       results.push({
         root,


### PR DESCRIPTION
Fixes #207

## Changes

### Bug 1: Case-sensitive path matching on Windows (Critical)

`findRootForPath()` did case-sensitive `startsWith` comparison. On Windows, chokidar emits `J:/domains/...` but config roots resolve to `j:/domains/...` — every VCS event silently dropped.

**Fix:** Added `normalizePathCase()` utility (lowercases on `win32`, identity elsewhere). Applied to all path comparison points:
- `findRootForPath()` — both sides normalized
- `VcsCoordinator` — Map keys and lookups normalized
- `resolveWatchRootsForGlob()` — comparison paths normalized

### Bug 2: No baseline commit for pre-existing files

Initial scan `add` events were suppressed from VCS by design. Pre-existing files never entered version control — no baseline snapshot was captured.

**Fix:** `VcsManager.start()` now calls `enqueueBaselineIfNeeded()`:
1. Checks `git rev-parse HEAD` — if no commits exist, enumerates untracked files
2. Feeds them through `fileChanged()` — existing `maxBatchSize`/`commitDebounceMs` throttle automatically
3. Baseline batches use template message (no AI generation)

`start()` is now async throughout the chain.

## Tests

- 3 new tests for mixed-case path matching
- 4 new tests for baseline commit flow
- 717/717 tests passing
