### PR TITLE
feat: declarative VCS git author identity in config

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,8 @@ export {
   type RenderBodySection,
   type RenderConfig,
   type SchemaEntry,
+  type VcsAuthorConfig,
+  vcsAuthorConfigSchema,
   type VcsCommitMessageConfig,
   vcsCommitMessageConfigSchema,
   type VcsConfig,

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -45,6 +45,8 @@ export {
   extractWatchPathStrings,
   type NormalizedWatchPath,
   normalizeWatchPaths,
+  type VcsAuthorConfig,
+  vcsAuthorConfigSchema,
   type VcsCommitMessageConfig,
   vcsCommitMessageConfigSchema,
   type VcsConfig,

--- a/packages/core/src/schemas/vcs.test.ts
+++ b/packages/core/src/schemas/vcs.test.ts
@@ -8,8 +8,10 @@ import { describe, expect, it } from 'vitest';
 import {
   extractWatchPathStrings,
   normalizeWatchPaths,
+  vcsAuthorConfigSchema,
   vcsConfigSchema,
   watchPathEntrySchema,
+  watchPathVcsConfigSchema,
 } from './vcs';
 
 describe('vcsConfigSchema', () => {
@@ -76,6 +78,71 @@ describe('vcsConfigSchema', () => {
   it('all fields are optional at top level', () => {
     const result = vcsConfigSchema.safeParse({});
     expect(result.success).toBe(true);
+  });
+});
+
+describe('vcsAuthorConfigSchema', () => {
+  it('applies default name and email', () => {
+    const result = vcsAuthorConfigSchema.parse({});
+    expect(result.name).toBe('jeeves-watcher');
+    expect(result.email).toBe('watcher@localhost');
+  });
+
+  it('accepts custom name and email', () => {
+    const result = vcsAuthorConfigSchema.parse({
+      name: 'my-bot',
+      email: 'bot@example.com',
+    });
+    expect(result.name).toBe('my-bot');
+    expect(result.email).toBe('bot@example.com');
+  });
+
+  it('allows partial override — name only', () => {
+    const result = vcsAuthorConfigSchema.parse({ name: 'custom-name' });
+    expect(result.name).toBe('custom-name');
+    expect(result.email).toBe('watcher@localhost');
+  });
+
+  it('allows partial override — email only', () => {
+    const result = vcsAuthorConfigSchema.parse({ email: 'custom@example.com' });
+    expect(result.name).toBe('jeeves-watcher');
+    expect(result.email).toBe('custom@example.com');
+  });
+});
+
+describe('vcsConfigSchema author field', () => {
+  it('author is optional and undefined by default', () => {
+    const result = vcsConfigSchema.parse({});
+    expect(result.author).toBeUndefined();
+  });
+
+  it('applies author defaults when empty object provided', () => {
+    const result = vcsConfigSchema.parse({ author: {} });
+    expect(result.author!.name).toBe('jeeves-watcher');
+    expect(result.author!.email).toBe('watcher@localhost');
+  });
+
+  it('accepts custom author', () => {
+    const result = vcsConfigSchema.parse({
+      author: { name: 'deploy-bot', email: 'deploy@ci.local' },
+    });
+    expect(result.author!.name).toBe('deploy-bot');
+    expect(result.author!.email).toBe('deploy@ci.local');
+  });
+});
+
+describe('watchPathVcsConfigSchema author field', () => {
+  it('inherits author from vcsConfigSchema extension', () => {
+    const result = watchPathVcsConfigSchema.parse({
+      author: { name: 'path-bot', email: 'path@local' },
+    });
+    expect(result.author!.name).toBe('path-bot');
+    expect(result.author!.email).toBe('path@local');
+  });
+
+  it('author is optional in per-path config', () => {
+    const result = watchPathVcsConfigSchema.parse({});
+    expect(result.author).toBeUndefined();
   });
 });
 

--- a/packages/core/src/schemas/vcs.ts
+++ b/packages/core/src/schemas/vcs.ts
@@ -73,6 +73,25 @@ export const vcsRetentionConfigSchema = z.object({
 export type VcsRetentionConfig = z.infer<typeof vcsRetentionConfigSchema>;
 
 /**
+ * Git commit author identity configuration.
+ */
+export const vcsAuthorConfigSchema = z.object({
+  /** Author name for git commits. */
+  name: z
+    .string()
+    .default('jeeves-watcher')
+    .describe('Author name for git commits. Default: "jeeves-watcher".'),
+  /** Author email for git commits. */
+  email: z
+    .string()
+    .default('watcher@localhost')
+    .describe('Author email for git commits. Default: "watcher@localhost".'),
+});
+
+/** Git commit author identity configuration. */
+export type VcsAuthorConfig = z.infer<typeof vcsAuthorConfigSchema>;
+
+/**
  * Root-level VCS configuration.
  */
 export const vcsConfigSchema = z.object({
@@ -82,6 +101,12 @@ export const vcsConfigSchema = z.object({
     .default(false)
     .describe(
       'Enable git-backed version control of watched content. Default: false.',
+    ),
+  /** Git commit author identity. Set per-repo during init. */
+  author: vcsAuthorConfigSchema
+    .optional()
+    .describe(
+      'Git commit author identity. Set per-repo during init. Defaults: name="jeeves-watcher", email="watcher@localhost".',
     ),
   /** Debounce interval in milliseconds for batching commits. */
   commitDebounceMs: z

--- a/packages/core/src/schemas/vcs.ts
+++ b/packages/core/src/schemas/vcs.ts
@@ -79,11 +79,13 @@ export const vcsAuthorConfigSchema = z.object({
   /** Author name for git commits. */
   name: z
     .string()
+    .min(1)
     .default('jeeves-watcher')
     .describe('Author name for git commits. Default: "jeeves-watcher".'),
   /** Author email for git commits. */
   email: z
     .string()
+    .min(1)
     .default('watcher@localhost')
     .describe('Author email for git commits. Default: "watcher@localhost".'),
 });

--- a/packages/service/config.schema.json
+++ b/packages/service/config.schema.json
@@ -435,10 +435,12 @@
       }
     },
     "__schema12": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "__schema13": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "__schema14": {
       "default": 30000,

--- a/packages/service/config.schema.json
+++ b/packages/service/config.schema.json
@@ -25,25 +25,25 @@
           "$ref": "#/definitions/__schema5"
         },
         "ignored": {
-          "$ref": "#/definitions/__schema29"
-        },
-        "pollIntervalMs": {
-          "$ref": "#/definitions/__schema31"
-        },
-        "usePolling": {
           "$ref": "#/definitions/__schema33"
         },
-        "debounceMs": {
+        "pollIntervalMs": {
           "$ref": "#/definitions/__schema35"
         },
-        "stabilityThresholdMs": {
+        "usePolling": {
           "$ref": "#/definitions/__schema37"
         },
-        "respectGitignore": {
+        "debounceMs": {
           "$ref": "#/definitions/__schema39"
         },
-        "moveDetection": {
+        "stabilityThresholdMs": {
           "$ref": "#/definitions/__schema41"
+        },
+        "respectGitignore": {
+          "$ref": "#/definitions/__schema43"
+        },
+        "moveDetection": {
+          "$ref": "#/definitions/__schema45"
         }
       },
       "required": [
@@ -55,7 +55,7 @@
       "description": "Configuration file watch settings.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema45"
+          "$ref": "#/definitions/__schema49"
         }
       ]
     },
@@ -63,28 +63,28 @@
       "type": "object",
       "properties": {
         "provider": {
-          "$ref": "#/definitions/__schema49"
-        },
-        "model": {
-          "$ref": "#/definitions/__schema51"
-        },
-        "chunkSize": {
           "$ref": "#/definitions/__schema53"
         },
-        "chunkOverlap": {
+        "model": {
           "$ref": "#/definitions/__schema55"
         },
-        "dimensions": {
+        "chunkSize": {
           "$ref": "#/definitions/__schema57"
         },
-        "apiKey": {
+        "chunkOverlap": {
           "$ref": "#/definitions/__schema59"
         },
-        "rateLimitPerMinute": {
+        "dimensions": {
           "$ref": "#/definitions/__schema61"
         },
-        "concurrency": {
+        "apiKey": {
           "$ref": "#/definitions/__schema63"
+        },
+        "rateLimitPerMinute": {
+          "$ref": "#/definitions/__schema65"
+        },
+        "concurrency": {
+          "$ref": "#/definitions/__schema67"
         }
       },
       "description": "Embedding model configuration."
@@ -93,13 +93,13 @@
       "type": "object",
       "properties": {
         "url": {
-          "$ref": "#/definitions/__schema65"
+          "$ref": "#/definitions/__schema69"
         },
         "collectionName": {
-          "$ref": "#/definitions/__schema66"
+          "$ref": "#/definitions/__schema70"
         },
         "apiKey": {
-          "$ref": "#/definitions/__schema67"
+          "$ref": "#/definitions/__schema71"
         }
       },
       "required": [
@@ -112,7 +112,7 @@
       "description": "API server configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema69"
+          "$ref": "#/definitions/__schema73"
         }
       ]
     },
@@ -120,7 +120,7 @@
       "description": "Directory for persistent state files (issues.json, values.json, enrichments.sqlite). Defaults to .jeeves-metadata.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema73"
+          "$ref": "#/definitions/__schema77"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "description": "Rules for inferring metadata from file attributes. Each entry may be an inline rule object or a file path to a JSON rule file (resolved relative to config directory).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema74"
+          "$ref": "#/definitions/__schema78"
         }
       ]
     },
@@ -136,7 +136,7 @@
       "description": "Reusable named JsonMap transformations (inline definition or .json file path resolved relative to config directory).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema101"
+          "$ref": "#/definitions/__schema105"
         }
       ]
     },
@@ -144,7 +144,7 @@
       "description": "Named reusable Handlebars templates (inline strings or .hbs/.handlebars file paths).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema102"
+          "$ref": "#/definitions/__schema106"
         }
       ]
     },
@@ -152,7 +152,7 @@
       "description": "Custom Handlebars helper registration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema103"
+          "$ref": "#/definitions/__schema107"
         }
       ]
     },
@@ -160,7 +160,7 @@
       "description": "Custom JsonMap lib function registration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema104"
+          "$ref": "#/definitions/__schema108"
         }
       ]
     },
@@ -168,7 +168,7 @@
       "description": "Reindex configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema105"
+          "$ref": "#/definitions/__schema109"
         }
       ]
     },
@@ -176,7 +176,7 @@
       "description": "Search configuration including score thresholds and hybrid search.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema107"
+          "$ref": "#/definitions/__schema111"
         }
       ]
     },
@@ -184,7 +184,7 @@
       "description": "VCS configuration for git-backed version control of watched content.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema108"
+          "$ref": "#/definitions/__schema112"
         }
       ]
     },
@@ -192,7 +192,7 @@
       "description": "Logging configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema109"
+          "$ref": "#/definitions/__schema113"
         }
       ]
     },
@@ -200,7 +200,7 @@
       "description": "Timeout in milliseconds for graceful shutdown.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema112"
+          "$ref": "#/definitions/__schema116"
         }
       ]
     },
@@ -208,7 +208,7 @@
       "description": "Maximum consecutive system-level failures before triggering fatal error. Default: Infinity.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema113"
+          "$ref": "#/definitions/__schema117"
         }
       ]
     },
@@ -216,7 +216,7 @@
       "description": "Maximum backoff delay in milliseconds for system errors. Default: 60000.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema114"
+          "$ref": "#/definitions/__schema118"
         }
       ]
     }
@@ -331,38 +331,45 @@
             }
           ]
         },
-        "commitDebounceMs": {
+        "author": {
           "allOf": [
             {
               "$ref": "#/definitions/__schema10"
             }
           ]
         },
-        "maxBatchSize": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/__schema12"
-            }
-          ]
-        },
-        "commitMessage": {
+        "commitDebounceMs": {
           "allOf": [
             {
               "$ref": "#/definitions/__schema14"
             }
           ]
         },
+        "maxBatchSize": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema16"
+            }
+          ]
+        },
+        "commitMessage": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema18"
+            }
+          ]
+        },
         "retention": {
           "allOf": [
             {
-              "$ref": "#/definitions/__schema20"
+              "$ref": "#/definitions/__schema24"
             }
           ]
         },
         "defaultAccessToken": {
           "allOf": [
             {
-              "$ref": "#/definitions/__schema25"
+              "$ref": "#/definitions/__schema29"
             }
           ]
         },
@@ -370,7 +377,7 @@
           "description": "Git remote URL for this watch root.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema27"
+              "$ref": "#/definitions/__schema31"
             }
           ]
         },
@@ -378,7 +385,7 @@
           "description": "Access token override for this watch root. Supports env var substitution (e.g., \"${GIT_TOKEN}\").",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema28"
+              "$ref": "#/definitions/__schema32"
             }
           ]
         }
@@ -397,8 +404,7 @@
       "type": "boolean"
     },
     "__schema10": {
-      "default": 30000,
-      "description": "Debounce interval in milliseconds for batching commits. Default: 30000.",
+      "description": "Git commit author identity. Set per-repo during init. Defaults: name=\"jeeves-watcher\", email=\"watcher@localhost\".",
       "allOf": [
         {
           "$ref": "#/definitions/__schema11"
@@ -406,26 +412,37 @@
       ]
     },
     "__schema11": {
-      "type": "integer",
-      "minimum": 1000,
-      "maximum": 9007199254740991
+      "type": "object",
+      "properties": {
+        "name": {
+          "default": "jeeves-watcher",
+          "description": "Author name for git commits. Default: \"jeeves-watcher\".",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema12"
+            }
+          ]
+        },
+        "email": {
+          "default": "watcher@localhost",
+          "description": "Author email for git commits. Default: \"watcher@localhost\".",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema13"
+            }
+          ]
+        }
+      }
     },
     "__schema12": {
-      "default": 1000,
-      "description": "Maximum number of files per commit batch. Default: 1000.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema13"
-        }
-      ]
+      "type": "string"
     },
     "__schema13": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 9007199254740991
+      "type": "string"
     },
     "__schema14": {
-      "description": "AI-generated commit message configuration.",
+      "default": 30000,
+      "description": "Debounce interval in milliseconds for batching commits. Default: 30000.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema15"
@@ -433,6 +450,33 @@
       ]
     },
     "__schema15": {
+      "type": "integer",
+      "minimum": 1000,
+      "maximum": 9007199254740991
+    },
+    "__schema16": {
+      "default": 1000,
+      "description": "Maximum number of files per commit batch. Default: 1000.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema17"
+        }
+      ]
+    },
+    "__schema17": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "__schema18": {
+      "description": "AI-generated commit message configuration.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema19"
+        }
+      ]
+    },
+    "__schema19": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -440,7 +484,7 @@
           "description": "Enable AI-generated commit messages. Default: true.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema16"
+              "$ref": "#/definitions/__schema20"
             }
           ]
         },
@@ -449,7 +493,7 @@
           "description": "AI provider for commit message generation. Default: \"anthropic\".",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema17"
+              "$ref": "#/definitions/__schema21"
             }
           ]
         },
@@ -458,7 +502,7 @@
           "description": "AI model for commit message generation. Default: \"claude-haiku-4-0\".",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema18"
+              "$ref": "#/definitions/__schema22"
             }
           ]
         },
@@ -466,33 +510,33 @@
           "description": "API key for commit message provider. Supports env var substitution (e.g., \"${ANTHROPIC_API_KEY}\").",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema19"
+              "$ref": "#/definitions/__schema23"
             }
           ]
         }
       }
     },
-    "__schema16": {
+    "__schema20": {
       "type": "boolean"
     },
-    "__schema17": {
+    "__schema21": {
       "type": "string"
     },
-    "__schema18": {
+    "__schema22": {
       "type": "string"
     },
-    "__schema19": {
+    "__schema23": {
       "type": "string"
     },
-    "__schema20": {
+    "__schema24": {
       "description": "Version retention policy configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema21"
+          "$ref": "#/definitions/__schema25"
         }
       ]
     },
-    "__schema21": {
+    "__schema25": {
       "type": "object",
       "properties": {
         "maxAgeDays": {
@@ -500,7 +544,7 @@
           "description": "Maximum age in days for retained versions. Default: 30.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema22"
+              "$ref": "#/definitions/__schema26"
             }
           ]
         },
@@ -509,7 +553,7 @@
           "description": "Maximum number of versions to retain per file. Default: 100.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema23"
+              "$ref": "#/definitions/__schema27"
             }
           ]
         },
@@ -518,47 +562,27 @@
           "description": "Cron expression for squash schedule. Default: \"0 0 * * *\" (daily at midnight).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema24"
+              "$ref": "#/definitions/__schema28"
             }
           ]
         }
       }
     },
-    "__schema22": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 9007199254740991
-    },
-    "__schema23": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 9007199254740991
-    },
-    "__schema24": {
-      "type": "string"
-    },
-    "__schema25": {
-      "description": "Default git access token for all roots. Supports env var substitution (e.g., \"${GIT_TOKEN}\").",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema26"
-        }
-      ]
-    },
     "__schema26": {
-      "type": "string"
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
     },
     "__schema27": {
-      "type": "string"
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
     },
     "__schema28": {
       "type": "string"
     },
     "__schema29": {
-      "default": [
-        "**/node_modules/**"
-      ],
-      "description": "Glob patterns to exclude from watching (e.g., \"**/node_modules/**\").",
+      "description": "Default git access token for all roots. Supports env var substitution (e.g., \"${GIT_TOKEN}\").",
       "allOf": [
         {
           "$ref": "#/definitions/__schema30"
@@ -566,24 +590,19 @@
       ]
     },
     "__schema30": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "type": "string"
     },
     "__schema31": {
-      "description": "Polling interval in milliseconds when usePolling is enabled.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema32"
-        }
-      ]
+      "type": "string"
     },
     "__schema32": {
-      "type": "number"
+      "type": "string"
     },
     "__schema33": {
-      "description": "Use polling instead of native file system events (for network drives).",
+      "default": [
+        "**/node_modules/**"
+      ],
+      "description": "Glob patterns to exclude from watching (e.g., \"**/node_modules/**\").",
       "allOf": [
         {
           "$ref": "#/definitions/__schema34"
@@ -591,10 +610,13 @@
       ]
     },
     "__schema34": {
-      "type": "boolean"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "__schema35": {
-      "description": "Debounce delay in milliseconds for file change events.",
+      "description": "Polling interval in milliseconds when usePolling is enabled.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema36"
@@ -605,7 +627,7 @@
       "type": "number"
     },
     "__schema37": {
-      "description": "Time in milliseconds a file must remain unchanged before processing.",
+      "description": "Use polling instead of native file system events (for network drives).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema38"
@@ -613,10 +635,10 @@
       ]
     },
     "__schema38": {
-      "type": "number"
+      "type": "boolean"
     },
     "__schema39": {
-      "description": "Skip files ignored by .gitignore in git repositories. Only applies to repos with a .git directory. Default: true.",
+      "description": "Debounce delay in milliseconds for file change events.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema40"
@@ -624,10 +646,10 @@
       ]
     },
     "__schema40": {
-      "type": "boolean"
+      "type": "number"
     },
     "__schema41": {
-      "description": "Move detection: correlate unlink+add events as file moves to avoid re-embedding.",
+      "description": "Time in milliseconds a file must remain unchanged before processing.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema42"
@@ -635,6 +657,28 @@
       ]
     },
     "__schema42": {
+      "type": "number"
+    },
+    "__schema43": {
+      "description": "Skip files ignored by .gitignore in git repositories. Only applies to repos with a .git directory. Default: true.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema44"
+        }
+      ]
+    },
+    "__schema44": {
+      "type": "boolean"
+    },
+    "__schema45": {
+      "description": "Move detection: correlate unlink+add events as file moves to avoid re-embedding.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema46"
+        }
+      ]
+    },
+    "__schema46": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -642,7 +686,7 @@
           "description": "Enable move detection via content hash correlation.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema43"
+              "$ref": "#/definitions/__schema47"
             }
           ]
         },
@@ -651,28 +695,28 @@
           "description": "How long (ms) to buffer unlink events before treating as deletes.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema44"
+              "$ref": "#/definitions/__schema48"
             }
           ]
         }
       }
     },
-    "__schema43": {
+    "__schema47": {
       "type": "boolean"
     },
-    "__schema44": {
+    "__schema48": {
       "type": "integer",
       "minimum": 100,
       "maximum": 9007199254740991
     },
-    "__schema45": {
+    "__schema49": {
       "type": "object",
       "properties": {
         "enabled": {
           "description": "Enable automatic reloading when config file changes.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema46"
+              "$ref": "#/definitions/__schema50"
             }
           ]
         },
@@ -680,7 +724,7 @@
           "description": "Debounce delay in milliseconds for config file change detection.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema47"
+              "$ref": "#/definitions/__schema51"
             }
           ]
         },
@@ -688,19 +732,19 @@
           "description": "Reindex scope triggered on config change. Default: issues.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema48"
+              "$ref": "#/definitions/__schema52"
             }
           ]
         }
       }
     },
-    "__schema46": {
+    "__schema50": {
       "type": "boolean"
     },
-    "__schema47": {
+    "__schema51": {
       "type": "number"
     },
-    "__schema48": {
+    "__schema52": {
       "anyOf": [
         {
           "type": "string",
@@ -719,32 +763,9 @@
         }
       ]
     },
-    "__schema49": {
+    "__schema53": {
       "default": "gemini",
       "description": "Embedding provider name (e.g., \"gemini\", \"openai\").",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema50"
-        }
-      ]
-    },
-    "__schema50": {
-      "type": "string"
-    },
-    "__schema51": {
-      "default": "gemini-embedding-001",
-      "description": "Embedding model identifier (e.g., \"gemini-embedding-001\", \"text-embedding-3-small\").",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema52"
-        }
-      ]
-    },
-    "__schema52": {
-      "type": "string"
-    },
-    "__schema53": {
-      "description": "Maximum chunk size in characters for text splitting.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema54"
@@ -752,10 +773,11 @@
       ]
     },
     "__schema54": {
-      "type": "number"
+      "type": "string"
     },
     "__schema55": {
-      "description": "Character overlap between consecutive chunks.",
+      "default": "gemini-embedding-001",
+      "description": "Embedding model identifier (e.g., \"gemini-embedding-001\", \"text-embedding-3-small\").",
       "allOf": [
         {
           "$ref": "#/definitions/__schema56"
@@ -763,10 +785,10 @@
       ]
     },
     "__schema56": {
-      "type": "number"
+      "type": "string"
     },
     "__schema57": {
-      "description": "Embedding vector dimensions (must match model output).",
+      "description": "Maximum chunk size in characters for text splitting.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema58"
@@ -777,7 +799,7 @@
       "type": "number"
     },
     "__schema59": {
-      "description": "API key for embedding provider (supports ${ENV_VAR} substitution).",
+      "description": "Character overlap between consecutive chunks.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema60"
@@ -785,10 +807,10 @@
       ]
     },
     "__schema60": {
-      "type": "string"
+      "type": "number"
     },
     "__schema61": {
-      "description": "Maximum embedding API requests per minute (rate limiting).",
+      "description": "Embedding vector dimensions (must match model output).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema62"
@@ -799,7 +821,7 @@
       "type": "number"
     },
     "__schema63": {
-      "description": "Maximum concurrent embedding requests.",
+      "description": "API key for embedding provider (supports ${ENV_VAR} substitution).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema64"
@@ -807,18 +829,21 @@
       ]
     },
     "__schema64": {
-      "type": "number"
+      "type": "string"
     },
     "__schema65": {
-      "type": "string",
-      "description": "Qdrant server URL (e.g., \"http://localhost:6333\")."
+      "description": "Maximum embedding API requests per minute (rate limiting).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema66"
+        }
+      ]
     },
     "__schema66": {
-      "type": "string",
-      "description": "Qdrant collection name for vector storage."
+      "type": "number"
     },
     "__schema67": {
-      "description": "Qdrant API key for authentication (supports ${ENV_VAR} substitution).",
+      "description": "Maximum concurrent embedding requests.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema68"
@@ -826,16 +851,35 @@
       ]
     },
     "__schema68": {
-      "type": "string"
+      "type": "number"
     },
     "__schema69": {
+      "type": "string",
+      "description": "Qdrant server URL (e.g., \"http://localhost:6333\")."
+    },
+    "__schema70": {
+      "type": "string",
+      "description": "Qdrant collection name for vector storage."
+    },
+    "__schema71": {
+      "description": "Qdrant API key for authentication (supports ${ENV_VAR} substitution).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema72"
+        }
+      ]
+    },
+    "__schema72": {
+      "type": "string"
+    },
+    "__schema73": {
       "type": "object",
       "properties": {
         "host": {
           "description": "Host address for API server (e.g., \"127.0.0.1\", \"0.0.0.0\").",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema70"
+              "$ref": "#/definitions/__schema74"
             }
           ]
         },
@@ -843,7 +887,7 @@
           "description": "Port for API server (e.g., 1936).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema71"
+              "$ref": "#/definitions/__schema75"
             }
           ]
         },
@@ -851,25 +895,25 @@
           "description": "TTL in milliseconds for caching read-heavy endpoints (e.g., /status, /config). Default: 30000.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema72"
+              "$ref": "#/definitions/__schema76"
             }
           ]
         }
       }
     },
-    "__schema70": {
-      "type": "string"
-    },
-    "__schema71": {
-      "type": "number"
-    },
-    "__schema72": {
-      "type": "number"
-    },
-    "__schema73": {
-      "type": "string"
-    },
     "__schema74": {
+      "type": "string"
+    },
+    "__schema75": {
+      "type": "number"
+    },
+    "__schema76": {
+      "type": "number"
+    },
+    "__schema77": {
+      "type": "string"
+    },
+    "__schema78": {
       "type": "array",
       "items": {
         "anyOf": [
@@ -877,28 +921,28 @@
             "type": "object",
             "properties": {
               "name": {
-                "$ref": "#/definitions/__schema75"
+                "$ref": "#/definitions/__schema79"
               },
               "description": {
-                "$ref": "#/definitions/__schema76"
-              },
-              "match": {
-                "$ref": "#/definitions/__schema77"
-              },
-              "schema": {
                 "$ref": "#/definitions/__schema80"
               },
-              "map": {
-                "$ref": "#/definitions/__schema82"
+              "match": {
+                "$ref": "#/definitions/__schema81"
               },
-              "template": {
+              "schema": {
+                "$ref": "#/definitions/__schema84"
+              },
+              "map": {
                 "$ref": "#/definitions/__schema86"
               },
+              "template": {
+                "$ref": "#/definitions/__schema90"
+              },
               "render": {
-                "$ref": "#/definitions/__schema88"
+                "$ref": "#/definitions/__schema92"
               },
               "renderAs": {
-                "$ref": "#/definitions/__schema99"
+                "$ref": "#/definitions/__schema103"
               }
             },
             "required": [
@@ -913,39 +957,39 @@
         ]
       }
     },
-    "__schema75": {
+    "__schema79": {
       "type": "string",
       "minLength": 1,
       "description": "Unique name identifying this inference rule."
     },
-    "__schema76": {
+    "__schema80": {
       "type": "string",
       "minLength": 1,
       "description": "Human-readable description of what this rule does."
     },
-    "__schema77": {
+    "__schema81": {
       "type": "object",
       "propertyNames": {
-        "$ref": "#/definitions/__schema78"
+        "$ref": "#/definitions/__schema82"
       },
       "additionalProperties": {
-        "$ref": "#/definitions/__schema79"
+        "$ref": "#/definitions/__schema83"
       },
       "description": "JSON Schema object to match against file attributes."
     },
-    "__schema78": {
+    "__schema82": {
       "type": "string"
     },
-    "__schema79": {},
-    "__schema80": {
+    "__schema83": {},
+    "__schema84": {
       "description": "Array of schema references (named schema refs or inline objects) merged left-to-right.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema81"
+          "$ref": "#/definitions/__schema85"
         }
       ]
     },
-    "__schema81": {
+    "__schema85": {
       "type": "array",
       "items": {
         "anyOf": [
@@ -959,25 +1003,25 @@
         ]
       }
     },
-    "__schema82": {
+    "__schema86": {
       "description": "JsonMap transformation (inline definition, named map reference, or .json file path).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema83"
+          "$ref": "#/definitions/__schema87"
         }
       ]
     },
-    "__schema83": {
+    "__schema87": {
       "anyOf": [
         {
-          "$ref": "#/definitions/__schema84"
+          "$ref": "#/definitions/__schema88"
         },
         {
           "type": "string"
         }
       ]
     },
-    "__schema84": {
+    "__schema88": {
       "anyOf": [
         {
           "anyOf": [
@@ -1003,7 +1047,7 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "$ref": "#/definitions/__schema84"
+                "$ref": "#/definitions/__schema88"
               },
               {
                 "type": "object",
@@ -1011,12 +1055,12 @@
                   "$": {
                     "anyOf": [
                       {
-                        "$ref": "#/definitions/__schema85"
+                        "$ref": "#/definitions/__schema89"
                       },
                       {
                         "type": "array",
                         "items": {
-                          "$ref": "#/definitions/__schema85"
+                          "$ref": "#/definitions/__schema89"
                         }
                       }
                     ]
@@ -1032,12 +1076,12 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/__schema84"
+            "$ref": "#/definitions/__schema88"
           }
         }
       ]
     },
-    "__schema85": {
+    "__schema89": {
       "type": "object",
       "properties": {
         "method": {
@@ -1062,39 +1106,39 @@
         "params"
       ]
     },
-    "__schema86": {
+    "__schema90": {
       "description": "Handlebars content template (inline string, named ref, or .hbs/.handlebars file path).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema87"
+          "$ref": "#/definitions/__schema91"
         }
       ]
     },
-    "__schema87": {
+    "__schema91": {
       "type": "string"
     },
-    "__schema88": {
+    "__schema92": {
       "description": "Declarative render configuration for frontmatter + structured Markdown output (mutually exclusive with template).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema89"
+          "$ref": "#/definitions/__schema93"
         }
       ]
     },
-    "__schema89": {
+    "__schema93": {
       "type": "object",
       "properties": {
         "frontmatter": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/__schema90"
+            "$ref": "#/definitions/__schema94"
           },
           "description": "Keys or glob patterns to include as YAML frontmatter. Supports picomatch globs (e.g. \"*\") and \"!\"-prefixed exclusion patterns (e.g. \"!_*\"). Explicit names preserve declaration order; glob-matched keys are sorted alphabetically."
         },
         "body": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/__schema91"
+            "$ref": "#/definitions/__schema95"
           },
           "description": "Ordered markdown body sections."
         }
@@ -1104,11 +1148,11 @@
         "body"
       ]
     },
-    "__schema90": {
+    "__schema94": {
       "type": "string",
       "minLength": 1
     },
-    "__schema91": {
+    "__schema95": {
       "type": "object",
       "properties": {
         "path": {
@@ -1126,7 +1170,7 @@
           "description": "Override heading text.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema92"
+              "$ref": "#/definitions/__schema96"
             }
           ]
         },
@@ -1134,7 +1178,7 @@
           "description": "Name of a registered Handlebars helper used as a format handler.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema93"
+              "$ref": "#/definitions/__schema97"
             }
           ]
         },
@@ -1142,7 +1186,7 @@
           "description": "Additional args passed to the format helper.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema94"
+              "$ref": "#/definitions/__schema98"
             }
           ]
         },
@@ -1150,7 +1194,7 @@
           "description": "If true, the value at path is treated as an array and iterated.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema95"
+              "$ref": "#/definitions/__schema99"
             }
           ]
         },
@@ -1158,7 +1202,7 @@
           "description": "Handlebars template string for per-item heading text (used when each=true).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema96"
+              "$ref": "#/definitions/__schema100"
             }
           ]
         },
@@ -1166,7 +1210,7 @@
           "description": "Key path within each item to use as renderable content (used when each=true).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema97"
+              "$ref": "#/definitions/__schema101"
             }
           ]
         },
@@ -1174,7 +1218,7 @@
           "description": "Key path within each item to sort by (used when each=true).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema98"
+              "$ref": "#/definitions/__schema102"
             }
           ]
         }
@@ -1184,19 +1228,6 @@
         "heading"
       ]
     },
-    "__schema92": {
-      "type": "string"
-    },
-    "__schema93": {
-      "type": "string"
-    },
-    "__schema94": {
-      "type": "array",
-      "items": {}
-    },
-    "__schema95": {
-      "type": "boolean"
-    },
     "__schema96": {
       "type": "string"
     },
@@ -1204,21 +1235,34 @@
       "type": "string"
     },
     "__schema98": {
-      "type": "string"
+      "type": "array",
+      "items": {}
     },
     "__schema99": {
+      "type": "boolean"
+    },
+    "__schema100": {
+      "type": "string"
+    },
+    "__schema101": {
+      "type": "string"
+    },
+    "__schema102": {
+      "type": "string"
+    },
+    "__schema103": {
       "description": "Output file extension override (without dot). Requires template or render.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema100"
+          "$ref": "#/definitions/__schema104"
         }
       ]
     },
-    "__schema100": {
+    "__schema104": {
       "type": "string",
       "pattern": "^[a-z0-9]{1,10}$"
     },
-    "__schema101": {
+    "__schema105": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1226,7 +1270,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "$ref": "#/definitions/__schema84"
+            "$ref": "#/definitions/__schema88"
           },
           {
             "type": "string"
@@ -1237,7 +1281,7 @@
               "map": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/__schema84"
+                    "$ref": "#/definitions/__schema88"
                   },
                   {
                     "type": "string"
@@ -1255,7 +1299,7 @@
         ]
       }
     },
-    "__schema102": {
+    "__schema106": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1282,7 +1326,7 @@
         ]
       }
     },
-    "__schema103": {
+    "__schema107": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1302,7 +1346,7 @@
         ]
       }
     },
-    "__schema104": {
+    "__schema108": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1322,7 +1366,7 @@
         ]
       }
     },
-    "__schema105": {
+    "__schema109": {
       "type": "object",
       "properties": {
         "callbackUrl": {
@@ -1334,18 +1378,18 @@
           "description": "Maximum concurrent file operations during reindex (default 50).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema106"
+              "$ref": "#/definitions/__schema110"
             }
           ]
         }
       }
     },
-    "__schema106": {
+    "__schema110": {
       "type": "integer",
       "minimum": 1,
       "maximum": 9007199254740991
     },
-    "__schema107": {
+    "__schema111": {
       "type": "object",
       "properties": {
         "scoreThresholds": {
@@ -1390,37 +1434,40 @@
         }
       }
     },
-    "__schema108": {
+    "__schema112": {
       "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/definitions/__schema8"
         },
-        "commitDebounceMs": {
+        "author": {
           "$ref": "#/definitions/__schema10"
         },
-        "maxBatchSize": {
-          "$ref": "#/definitions/__schema12"
-        },
-        "commitMessage": {
+        "commitDebounceMs": {
           "$ref": "#/definitions/__schema14"
         },
+        "maxBatchSize": {
+          "$ref": "#/definitions/__schema16"
+        },
+        "commitMessage": {
+          "$ref": "#/definitions/__schema18"
+        },
         "retention": {
-          "$ref": "#/definitions/__schema20"
+          "$ref": "#/definitions/__schema24"
         },
         "defaultAccessToken": {
-          "$ref": "#/definitions/__schema25"
+          "$ref": "#/definitions/__schema29"
         }
       }
     },
-    "__schema109": {
+    "__schema113": {
       "type": "object",
       "properties": {
         "level": {
           "description": "Logging level (trace, debug, info, warn, error, fatal).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema110"
+              "$ref": "#/definitions/__schema114"
             }
           ]
         },
@@ -1428,25 +1475,25 @@
           "description": "Path to log file (logs to stdout if omitted).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema111"
+              "$ref": "#/definitions/__schema115"
             }
           ]
         }
       }
     },
-    "__schema110": {
-      "type": "string"
-    },
-    "__schema111": {
-      "type": "string"
-    },
-    "__schema112": {
-      "type": "number"
-    },
-    "__schema113": {
-      "type": "number"
-    },
     "__schema114": {
+      "type": "string"
+    },
+    "__schema115": {
+      "type": "string"
+    },
+    "__schema116": {
+      "type": "number"
+    },
+    "__schema117": {
+      "type": "number"
+    },
+    "__schema118": {
       "type": "number"
     }
   }

--- a/packages/service/src/app/initialization.test.ts
+++ b/packages/service/src/app/initialization.test.ts
@@ -155,6 +155,7 @@ describe('watchConfigChanged', () => {
 vi.mock('../vcs', async (importOriginal) => ({
   ...(await importOriginal()),
   checkGitAvailable: vi.fn().mockResolvedValue(true),
+  configureRepoIdentity: vi.fn().mockResolvedValue(undefined),
   initRepo: vi.fn().mockResolvedValue(undefined),
   ensureGitignore: vi.fn().mockResolvedValue(undefined),
 }));
@@ -185,6 +186,90 @@ describe('initVcs', () => {
     expect(infoSpy).toHaveBeenCalledWith(
       expect.objectContaining({ root: '/some/path' }),
       'VCS initialized for watch root',
+    );
+  });
+
+  it('calls configureRepoIdentity with defaults when no author specified', async () => {
+    const { configureRepoIdentity: mockConfigure } = await import('../vcs');
+    const logger = pino({ level: 'silent' });
+
+    const config = {
+      vcs: {
+        enabled: true,
+        commitDebounceMs: 5000,
+        maxBatchSize: 1000,
+      },
+      watch: {
+        paths: ['/repo/root/**'],
+        ignored: [],
+      },
+    } as unknown as JeevesWatcherConfig;
+
+    await initVcs(config, logger);
+
+    expect(mockConfigure).toHaveBeenCalledWith(
+      '/repo/root',
+      'jeeves-watcher',
+      'watcher@localhost',
+    );
+  });
+
+  it('resolves root-level author config', async () => {
+    const { configureRepoIdentity: mockConfigure } = await import('../vcs');
+    vi.mocked(mockConfigure).mockClear();
+    const logger = pino({ level: 'silent' });
+
+    const config = {
+      vcs: {
+        enabled: true,
+        commitDebounceMs: 5000,
+        maxBatchSize: 1000,
+        author: { name: 'root-bot', email: 'root@bot.local' },
+      },
+      watch: {
+        paths: ['/repo/**'],
+        ignored: [],
+      },
+    } as unknown as JeevesWatcherConfig;
+
+    await initVcs(config, logger);
+
+    expect(mockConfigure).toHaveBeenCalledWith(
+      '/repo',
+      'root-bot',
+      'root@bot.local',
+    );
+  });
+
+  it('per-path author overrides root-level author', async () => {
+    const { configureRepoIdentity: mockConfigure } = await import('../vcs');
+    vi.mocked(mockConfigure).mockClear();
+    const logger = pino({ level: 'silent' });
+
+    const config = {
+      vcs: {
+        enabled: true,
+        commitDebounceMs: 5000,
+        maxBatchSize: 1000,
+        author: { name: 'root-bot', email: 'root@bot.local' },
+      },
+      watch: {
+        paths: [
+          {
+            path: '/override/**',
+            vcs: { author: { name: 'path-bot', email: 'path@bot.local' } },
+          },
+        ],
+        ignored: [],
+      },
+    } as unknown as JeevesWatcherConfig;
+
+    await initVcs(config, logger);
+
+    expect(mockConfigure).toHaveBeenCalledWith(
+      '/override',
+      'path-bot',
+      'path@bot.local',
     );
   });
 });

--- a/packages/service/src/app/initialization.ts
+++ b/packages/service/src/app/initialization.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import {
   extractWatchPathStrings,
   normalizeWatchPaths,
+  vcsAuthorConfigSchema,
 } from '@karmaniverous/jeeves-watcher-core';
 import type { JsonMapMap } from '@karmaniverous/jsonmap';
 import { packageDirectorySync } from 'package-directory';
@@ -338,17 +339,19 @@ export async function initVcs(
     await initRepo(root);
     await ensureGitignore(root);
 
-    // Resolve author identity: per-path → root-level → defaults.
+    // Resolve author identity: per-path → root-level → schema defaults.
+    const defaults = vcsAuthorConfigSchema.parse({});
     const pathAuthor = entry.vcs?.author;
     const rootAuthor = config.vcs.author;
-    const authorName = pathAuthor?.name ?? rootAuthor?.name ?? 'jeeves-watcher';
+    const authorName = pathAuthor?.name ?? rootAuthor?.name ?? defaults.name;
     const authorEmail =
-      pathAuthor?.email ?? rootAuthor?.email ?? 'watcher@localhost';
+      pathAuthor?.email ?? rootAuthor?.email ?? defaults.email;
     await configureRepoIdentity(root, authorName, authorEmail);
 
-    logger.info(
+    logger.info({ root }, 'VCS initialized for watch root');
+    logger.debug(
       { root, authorName, authorEmail },
-      'VCS initialized for watch root',
+      'VCS author identity configured',
     );
   }
 

--- a/packages/service/src/app/initialization.ts
+++ b/packages/service/src/app/initialization.ts
@@ -27,6 +27,7 @@ import { buildTemplateEngine, type TemplateEngine } from '../templates';
 import { normalizeError } from '../util/normalizeError';
 import {
   checkGitAvailable,
+  configureRepoIdentity,
   ensureGitignore,
   initRepo,
   validateStateDirOverlap,
@@ -336,7 +337,19 @@ export async function initVcs(
 
     await initRepo(root);
     await ensureGitignore(root);
-    logger.info({ root }, 'VCS initialized for watch root');
+
+    // Resolve author identity: per-path → root-level → defaults.
+    const pathAuthor = entry.vcs?.author;
+    const rootAuthor = config.vcs.author;
+    const authorName = pathAuthor?.name ?? rootAuthor?.name ?? 'jeeves-watcher';
+    const authorEmail =
+      pathAuthor?.email ?? rootAuthor?.email ?? 'watcher@localhost';
+    await configureRepoIdentity(root, authorName, authorEmail);
+
+    logger.info(
+      { root, authorName, authorEmail },
+      'VCS initialized for watch root',
+    );
   }
 
   return true;

--- a/packages/service/src/vcs/index.ts
+++ b/packages/service/src/vcs/index.ts
@@ -26,6 +26,7 @@ export { validateStateDirOverlap } from './validateStateDirOverlap.js';
 export {
   ALWAYS_GITIGNORE_ENTRIES,
   checkGitAvailable,
+  configureRepoIdentity,
   ensureGitignore,
   initRepo,
 } from './vcsBootstrap.js';

--- a/packages/service/src/vcs/vcsBootstrap.test.ts
+++ b/packages/service/src/vcs/vcsBootstrap.test.ts
@@ -9,7 +9,13 @@ import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { checkGitAvailable, ensureGitignore, initRepo } from './vcsBootstrap';
+import { execFileAsync } from './gitExec';
+import {
+  checkGitAvailable,
+  configureRepoIdentity,
+  ensureGitignore,
+  initRepo,
+} from './vcsBootstrap';
 
 // ─── checkGitAvailable ───
 
@@ -38,6 +44,54 @@ describe('initRepo', () => {
     await initRepo(tempDir);
     await initRepo(tempDir);
     await expect(access(join(tempDir, '.git'))).resolves.toBeUndefined();
+  });
+});
+
+// ─── configureRepoIdentity ───
+
+describe('configureRepoIdentity', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vcs-identity-'));
+    await initRepo(tempDir);
+  });
+
+  it('sets local git user.name and user.email', async () => {
+    await configureRepoIdentity(tempDir, 'test-bot', 'bot@test.local');
+
+    const { stdout: name } = await execFileAsync(
+      'git',
+      ['config', '--local', 'user.name'],
+      { cwd: tempDir },
+    );
+    const { stdout: email } = await execFileAsync(
+      'git',
+      ['config', '--local', 'user.email'],
+      { cwd: tempDir },
+    );
+
+    expect(name.trim()).toBe('test-bot');
+    expect(email.trim()).toBe('bot@test.local');
+  });
+
+  it('overwrites existing local identity', async () => {
+    await configureRepoIdentity(tempDir, 'first', 'first@test.local');
+    await configureRepoIdentity(tempDir, 'second', 'second@test.local');
+
+    const { stdout: name } = await execFileAsync(
+      'git',
+      ['config', '--local', 'user.name'],
+      { cwd: tempDir },
+    );
+    const { stdout: email } = await execFileAsync(
+      'git',
+      ['config', '--local', 'user.email'],
+      { cwd: tempDir },
+    );
+
+    expect(name.trim()).toBe('second');
+    expect(email.trim()).toBe('second@test.local');
   });
 });
 

--- a/packages/service/src/vcs/vcsBootstrap.ts
+++ b/packages/service/src/vcs/vcsBootstrap.ts
@@ -47,6 +47,27 @@ export async function initRepo(rootPath: string): Promise<void> {
 }
 
 /**
+ * Configure local git identity for a repository.
+ * Sets repo-level (not global) user.name and user.email.
+ *
+ * @param rootPath - Directory of the git repository.
+ * @param name - Author name for commits.
+ * @param email - Author email for commits.
+ */
+export async function configureRepoIdentity(
+  rootPath: string,
+  name: string,
+  email: string,
+): Promise<void> {
+  await execFileAsync('git', ['config', 'user.name', name], {
+    cwd: rootPath,
+  });
+  await execFileAsync('git', ['config', 'user.email', email], {
+    cwd: rootPath,
+  });
+}
+
+/**
  * Ensure a .gitignore file exists at rootPath with all always-on entries.
  * Creates the file if missing. Appends only entries not already present.
  *

--- a/packages/service/src/vcs/vcsBootstrap.ts
+++ b/packages/service/src/vcs/vcsBootstrap.ts
@@ -59,10 +59,10 @@ export async function configureRepoIdentity(
   name: string,
   email: string,
 ): Promise<void> {
-  await execFileAsync('git', ['config', 'user.name', name], {
+  await execFileAsync('git', ['config', '--local', 'user.name', name], {
     cwd: rootPath,
   });
-  await execFileAsync('git', ['config', 'user.email', email], {
+  await execFileAsync('git', ['config', '--local', 'user.email', email], {
     cwd: rootPath,
   });
 }


### PR DESCRIPTION
Fixes #209

## Changes

### Problem

VCS relied on ambient git config for `user.name`/`user.email`. When the watcher runs as a Windows service under `LocalSystem`, no global git config exists — every commit fails with "Author identity unknown" and files are re-queued in an infinite retry loop.

### Solution

Declare git author identity in the VCS config schema and set it per-repo during initialization.

#### Schema (`packages/core/src/schemas/vcs.ts`)
- New `vcsAuthorConfigSchema` with `name` (default: `"jeeves-watcher"`) and `email` (default: `"watcher@localhost"`)
- Added `author` field to `vcsConfigSchema` — per-path overrides inherit automatically

#### Bootstrap (`packages/service/src/vcs/vcsBootstrap.ts`)
- New `configureRepoIdentity(rootPath, name, email)` — sets local (repo-level) git config

#### Initialization (`packages/service/src/app/initialization.ts`)
- `initVcs()` calls `configureRepoIdentity()` after `initRepo()` + `ensureGitignore()`
- Resolution order: per-path `vcs.author` → root-level `vcs.author` → schema defaults

### Tests
- 13 new tests covering schema defaults, overrides, bootstrap, and initialization
- 722/722 passing
