### PR TITLE
fix: use stdin for git add to avoid ENAMETOOLONG on large batches

### DIFF
--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -9,7 +9,7 @@ import type pino from 'pino';
 import { normalizeError } from '../util/normalizeError';
 import { retry } from '../util/retry';
 import type { CommitMessageGenerator } from './CommitMessageGenerator';
-import { execFileAsync } from './gitExec';
+import { execFileAsync, gitAddViaStdin } from './gitExec';
 import { SquashManager } from './SquashManager';
 
 /** Metadata for a pending reversion to include in the commit message. */
@@ -355,9 +355,7 @@ export class VcsManager {
     try {
       await retry(
         async (attempt) => {
-          await execFileAsync('git', ['add', '--', ...files], {
-            cwd: this.rootPath,
-          });
+          await gitAddViaStdin(files, this.rootPath);
 
           // Build message after staging so getStagedDiff can see the changes
           // Skip AI for baselines and retries — use template directly

--- a/packages/service/src/vcs/gitExec.test.ts
+++ b/packages/service/src/vcs/gitExec.test.ts
@@ -1,11 +1,20 @@
 /**
  * @module vcs/gitExec.test
- * Unit tests for findRootForPath and isIndexLockError.
+ * Unit tests for findRootForPath, isIndexLockError, and gitAddViaStdin.
  */
 
-import { describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
 
-import { findRootForPath, isIndexLockError } from './gitExec';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { findRootForPath, gitAddViaStdin, isIndexLockError } from './gitExec';
+import { initRepo } from './vcsBootstrap';
+
+const execFileAsync = promisify(execFile);
 
 describe('findRootForPath', () => {
   it('returns matching root for path under a single root', () => {
@@ -47,6 +56,97 @@ describe('findRootForPath', () => {
   it('matches case-insensitively on Windows (exact path equals root)', () => {
     const roots = ['j:/domains'];
     expect(findRootForPath(roots, 'J:/domains', 'win32')).toBe('j:/domains');
+  });
+});
+
+describe('gitAddViaStdin', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'git-add-stdin-'));
+    await initRepo(tempDir);
+    await execFileAsync('git', ['config', 'user.email', 'test@test.com'], {
+      cwd: tempDir,
+    });
+    await execFileAsync('git', ['config', 'user.name', 'Test'], {
+      cwd: tempDir,
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('stages a single file', async () => {
+    const filePath = join(tempDir, 'hello.txt');
+    await writeFile(filePath, 'hello', 'utf8');
+
+    await gitAddViaStdin([filePath], tempDir);
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--cached', '--name-only'],
+      { cwd: tempDir },
+    );
+    expect(stdout.trim()).toBe('hello.txt');
+  });
+
+  it('stages multiple files in one call', async () => {
+    const paths: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const p = join(tempDir, `file${String(i)}.txt`);
+      await writeFile(p, `content ${String(i)}`, 'utf8');
+      paths.push(p);
+    }
+
+    await gitAddViaStdin(paths, tempDir);
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--cached', '--name-only'],
+      { cwd: tempDir },
+    );
+    const staged = stdout.trim().split('\n').sort();
+    expect(staged).toEqual([
+      'file0.txt',
+      'file1.txt',
+      'file2.txt',
+      'file3.txt',
+      'file4.txt',
+    ]);
+  });
+
+  it('stages deleted files correctly', async () => {
+    const filePath = join(tempDir, 'to-delete.txt');
+    await writeFile(filePath, 'content', 'utf8');
+    await execFileAsync('git', ['add', '.'], { cwd: tempDir });
+    await execFileAsync('git', ['commit', '-m', 'add file'], {
+      cwd: tempDir,
+    });
+
+    await rm(filePath);
+    await gitAddViaStdin([filePath], tempDir);
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--cached', '--name-status'],
+      { cwd: tempDir },
+    );
+    expect(stdout.trim()).toMatch(/^D\s+to-delete\.txt$/);
+  });
+
+  it('handles files with spaces in paths', async () => {
+    const filePath = join(tempDir, 'file with spaces.txt');
+    await writeFile(filePath, 'content', 'utf8');
+
+    await gitAddViaStdin([filePath], tempDir);
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--cached', '--name-only'],
+      { cwd: tempDir },
+    );
+    expect(stdout.trim()).toBe('file with spaces.txt');
   });
 });
 

--- a/packages/service/src/vcs/gitExec.ts
+++ b/packages/service/src/vcs/gitExec.ts
@@ -32,8 +32,17 @@ export function gitAddViaStdin(files: string[], cwd: string): Promise<void> {
         else resolve();
       },
     );
-    child.stdin!.write(files.join('\0'));
-    child.stdin!.end();
+    if (!child.stdin) {
+      reject(new Error('Failed to open stdin for git add'));
+      return;
+    }
+    // Suppress EPIPE — expected if git exits before we finish writing
+    child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EPIPE') {
+        reject(err);
+      }
+    });
+    child.stdin.end(files.join('\0'));
   });
 }
 

--- a/packages/service/src/vcs/gitExec.ts
+++ b/packages/service/src/vcs/gitExec.ts
@@ -10,6 +10,34 @@ import { promisify } from 'node:util';
 export const execFileAsync = promisify(execFile);
 
 /**
+ * Stage files via stdin to avoid ENAMETOOLONG on Windows.
+ *
+ * Uses `git add --pathspec-from-file=- --pathspec-file-nul` so the file list is piped
+ * through stdin (NUL-delimited) instead of passed as command-line
+ * arguments.  This sidesteps the Windows CreateProcessW 32 767-char
+ * limit that triggers ENAMETOOLONG when batches contain many files
+ * with long absolute paths.
+ *
+ * @param files - Absolute paths of files to stage.
+ * @param cwd   - Repository root (working directory for git).
+ */
+export function gitAddViaStdin(files: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      'git',
+      ['add', '--pathspec-from-file=-', '--pathspec-file-nul'],
+      { cwd },
+      (error: Error | null) => {
+        if (error) reject(error);
+        else resolve();
+      },
+    );
+    child.stdin!.write(files.join('\0'));
+    child.stdin!.end();
+  });
+}
+
+/**
  * Normalize a path for case-insensitive comparison on Windows.
  * On Windows, lowercases the entire path; on other platforms, returns as-is.
  *

--- a/packages/service/src/vcs/index.ts
+++ b/packages/service/src/vcs/index.ts
@@ -7,6 +7,7 @@ export { CommitMessageGenerator } from './CommitMessageGenerator.js';
 export {
   execFileAsync,
   findRootForPath,
+  gitAddViaStdin,
   isIndexLockError,
   normalizePathCase,
 } from './gitExec.js';


### PR DESCRIPTION
Fixes #211

## Problem

`commitBatch()` passes all file paths as command-line arguments to `git add -- ...files`. With `maxBatchSize=1000` and absolute paths averaging ~80 chars, the total command line exceeds Windows' 32,767-character `CreateProcessW` limit. Every batch for large roots fails with `spawn ENAMETOOLONG` in an infinite retry loop.

Small roots (≤409 files) commit fine; large roots (1000+ files per batch) never commit.

## Fix

New `gitAddViaStdin()` helper pipes NUL-delimited file paths via stdin using `git add --pathspec-from-file=- --pathspec-file-nul`. No command line length limit, no temp files.

Used `--pathspec-file-nul` instead of `-z` — git 2.52.0 on Windows rejects `-z` as `unknown switch 'z'`.

## Changes

- `gitExec.ts` — New `gitAddViaStdin(files, cwd)` helper
- `VcsManager.ts` — `commitBatch()` uses `gitAddViaStdin` instead of arg spreading
- `index.ts` — Export `gitAddViaStdin`
- `gitExec.test.ts` — 4 new tests (single file, multiple files, deleted files, paths with spaces)

## Audit

Only one spread pattern existed across all VCS code. No other `execFileAsync` calls spread file lists.

## Tests

726/726 passing.
