### PR TITLE
fix(vcs): eliminate redundant baseline enumeration (#214)

### DIFF
--- a/packages/service/src/app/configReload.ts
+++ b/packages/service/src/app/configReload.ts
@@ -20,9 +20,8 @@ import type { JeevesWatcherFactories } from './factories';
 import {
   buildTemplateEngineAndCustomMapLib,
   getConfigDir,
-  rebuildWatcher,
-  watchConfigChanged,
 } from './initialization';
+import { rebuildWatcher, watchConfigChanged } from './watcherFactory';
 
 /** Mutable state held by JeevesWatcher that reload needs to read/write. */
 interface ReloadableState {

--- a/packages/service/src/app/index.ts
+++ b/packages/service/src/app/index.ts
@@ -30,13 +30,13 @@ import { defaultFactories, type JeevesWatcherFactories } from './factories';
 import {
   buildTemplateEngineAndCustomMapLib,
   createProcessorConfig,
-  createWatcher,
   getConfigDir,
   initEmbeddingAndStore,
   initVcs,
   introspectHelpers,
   resolveVersion,
 } from './initialization';
+import { createWatcher } from './watcherFactory';
 
 type ApiServerOptions = Parameters<
   JeevesWatcherFactories['createApiServer']
@@ -107,6 +107,13 @@ export class JeevesWatcher {
    * Start the watcher, API server, and all components.
    */
   async start(): Promise<void> {
+    await this.initInfrastructure();
+    await this.initPipeline();
+    await this.startServicesAndWatcher();
+  }
+
+  /** Set up logger, VCS, embedding provider, and vector store. */
+  private async initInfrastructure(): Promise<void> {
     const logger = this.factories.createLogger(this.config.logging);
     this.logger = logger;
 
@@ -123,6 +130,11 @@ export class JeevesWatcher {
     if (this.config.search?.hybrid?.enabled) {
       await vectorStore.ensureTextIndex('chunk_text');
     }
+  }
+
+  /** Build the processing pipeline: rules, templates, processor, queue, VCS. */
+  private async initPipeline(): Promise<void> {
+    const logger = this.logger!;
 
     const compiledRules = this.factories.compileRules(
       this.config.inferenceRules ?? [],
@@ -144,23 +156,20 @@ export class JeevesWatcher {
     this.issuesManager = new IssuesManager(stateDir, logger);
     this.valuesManager = new ValuesManager(stateDir, logger);
     this.enrichmentStore = new EnrichmentStore(stateDir, logger);
-    const enrichmentStore = this.enrichmentStore;
     this.contentHashCache = new ContentHashCache();
-    const contentHashCache = this.contentHashCache;
 
-    const processor = this.factories.createDocumentProcessor({
+    this.processor = this.factories.createDocumentProcessor({
       config: processorConfig,
-      embeddingProvider,
-      vectorStore,
+      embeddingProvider: this.embeddingProvider!,
+      vectorStore: this.vectorStore!,
       compiledRules,
       logger,
       templateEngine,
-      enrichmentStore,
+      enrichmentStore: this.enrichmentStore,
       issuesManager: this.issuesManager,
       valuesManager: this.valuesManager,
-      contentHashCache,
+      contentHashCache: this.contentHashCache,
     });
-    this.processor = processor;
 
     this.queue = this.factories.createEventQueue({
       debounceMs: this.config.watch.debounceMs ?? 2000,
@@ -168,23 +177,28 @@ export class JeevesWatcher {
       rateLimitPerMinute: this.config.embedding.rateLimitPerMinute,
     });
 
-    const vcsCoordinator = new VcsCoordinator(this.config, logger);
-    this.vcsCoordinator = vcsCoordinator;
+    this.vcsCoordinator = new VcsCoordinator(this.config, logger);
+  }
+
+  /** Wire up watcher and VCS coordinator, then start all services. */
+  private async startServicesAndWatcher(): Promise<void> {
+    const logger = this.logger!;
+    const vcsCoordinator = this.vcsCoordinator!;
 
     const { watcher, gitignoreFilter } = createWatcher(
       this.config,
       this.factories,
-      this.queue,
-      processor,
+      this.queue!,
+      this.processor!,
       logger,
       this.runtimeOptions,
       this.initialScanTracker,
-      contentHashCache,
+      this.contentHashCache,
       (filePath, event) => {
         vcsCoordinator.onFileChange(filePath, event);
       },
       () => {
-        vcsCoordinator.onInitialScanComplete();
+        void vcsCoordinator.onInitialScanComplete();
       },
     );
     this.watcher = watcher;

--- a/packages/service/src/app/index.ts
+++ b/packages/service/src/app/index.ts
@@ -183,13 +183,16 @@ export class JeevesWatcher {
       (filePath, event) => {
         vcsCoordinator.onFileChange(filePath, event);
       },
+      () => {
+        vcsCoordinator.onInitialScanComplete();
+      },
     );
     this.watcher = watcher;
     this.gitignoreFilter = gitignoreFilter;
 
     this.server = await this.startApiServer();
 
-    await vcsCoordinator.start();
+    vcsCoordinator.start();
     this.watcher.start();
     this.startConfigWatch();
 

--- a/packages/service/src/app/initialization.test.ts
+++ b/packages/service/src/app/initialization.test.ts
@@ -8,13 +8,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { JeevesWatcherConfig } from '../config/types';
 import type { JeevesWatcherFactories } from './factories';
-import {
-  getConfigDir,
-  initVcs,
-  rebuildWatcher,
-  resolveMapsConfig,
-  watchConfigChanged,
-} from './initialization';
+import { getConfigDir, initVcs, resolveMapsConfig } from './initialization';
+import { rebuildWatcher, watchConfigChanged } from './watcherFactory';
 
 describe('resolveMapsConfig', () => {
   it('should return undefined for undefined input', () => {

--- a/packages/service/src/app/initialization.ts
+++ b/packages/service/src/app/initialization.ts
@@ -153,6 +153,7 @@ export function createWatcher(
     filePath: string,
     event: 'add' | 'change' | 'unlink',
   ) => void,
+  onInitialScanComplete?: () => void,
 ): { watcher: FileSystemWatcher; gitignoreFilter?: GitignoreFilter } {
   const respectGitignore = config.watch.respectGitignore ?? true;
   const gitignoreFilter = respectGitignore
@@ -172,6 +173,7 @@ export function createWatcher(
       initialScanTracker,
       contentHashCache,
       onVcsFileChange,
+      onInitialScanComplete,
     },
   );
 

--- a/packages/service/src/app/initialization.ts
+++ b/packages/service/src/app/initialization.ts
@@ -16,13 +16,9 @@ import type { JsonMapMap } from '@karmaniverous/jsonmap';
 import { packageDirectorySync } from 'package-directory';
 import type pino from 'pino';
 
-import type { InitialScanTracker } from '../api/InitialScanTracker';
-import type { ContentHashCache } from '../cache';
 import type { JeevesWatcherConfig } from '../config/types';
-import { GitignoreFilter } from '../gitignore';
 import { type AllHelpersIntrospection, introspectAllHelpers } from '../helpers';
-import type { DocumentProcessorInterface, ProcessorConfig } from '../processor';
-import type { EventQueue } from '../queue';
+import type { ProcessorConfig } from '../processor';
 import { loadCustomMapHelpers } from '../rules/apply';
 import { buildTemplateEngine, type TemplateEngine } from '../templates';
 import { normalizeError } from '../util/normalizeError';
@@ -33,7 +29,6 @@ import {
   initRepo,
   validateStateDirOverlap,
 } from '../vcs';
-import type { FileSystemWatcher } from '../watcher';
 import { globRoot } from '../watcher/globToDir.js';
 import type { JeevesWatcherFactories } from './factories';
 
@@ -134,53 +129,6 @@ export function createProcessorConfig(
 }
 
 /**
- * Create file system watcher with gitignore filtering.
- */
-export function createWatcher(
-  config: JeevesWatcherConfig,
-  factories: JeevesWatcherFactories,
-  queue: EventQueue,
-  processor: DocumentProcessorInterface,
-  logger: pino.Logger,
-  runtimeOptions: {
-    maxRetries?: number;
-    maxBackoffMs?: number;
-    onFatalError?: (error: unknown) => void;
-  },
-  initialScanTracker?: InitialScanTracker,
-  contentHashCache?: ContentHashCache,
-  onVcsFileChange?: (
-    filePath: string,
-    event: 'add' | 'change' | 'unlink',
-  ) => void,
-  onInitialScanComplete?: () => void,
-): { watcher: FileSystemWatcher; gitignoreFilter?: GitignoreFilter } {
-  const respectGitignore = config.watch.respectGitignore ?? true;
-  const gitignoreFilter = respectGitignore
-    ? new GitignoreFilter(extractWatchPathStrings(config.watch.paths))
-    : undefined;
-
-  const watcher = factories.createFileSystemWatcher(
-    config.watch,
-    queue,
-    processor,
-    logger,
-    {
-      maxRetries: config.maxRetries ?? runtimeOptions.maxRetries,
-      maxBackoffMs: config.maxBackoffMs ?? runtimeOptions.maxBackoffMs,
-      onFatalError: runtimeOptions.onFatalError,
-      gitignoreFilter,
-      initialScanTracker,
-      contentHashCache,
-      onVcsFileChange,
-      onInitialScanComplete,
-    },
-  );
-
-  return { watcher, gitignoreFilter };
-}
-
-/**
  * Introspect all helpers for merged document.
  */
 export async function introspectHelpers(
@@ -203,84 +151,14 @@ export function getConfigDir(configPath?: string): string {
   return configPath ? dirname(configPath) : '.';
 }
 
-/** State returned by {@link rebuildWatcher}. */
-interface WatcherState {
-  watcher: FileSystemWatcher;
-  gitignoreFilter?: GitignoreFilter;
-}
-
-/**
- * Tear down and rebuild the filesystem watcher with new config.
- * Falls back to the old watcher if the new one fails to start.
- */
-export async function rebuildWatcher(
-  newConfig: JeevesWatcherConfig,
-  factories: JeevesWatcherFactories,
-  queue: EventQueue,
-  processor: DocumentProcessorInterface,
-  logger: pino.Logger,
-  runtimeOptions: {
-    maxRetries?: number;
-    maxBackoffMs?: number;
-    onFatalError?: (error: unknown) => void;
-  },
-  oldState: WatcherState,
-  initialScanTracker?: InitialScanTracker,
-  contentHashCache?: ContentHashCache,
-): Promise<WatcherState> {
-  try {
-    await oldState.watcher.stop();
-
-    const { watcher: newWatcher, gitignoreFilter: newGitignoreFilter } =
-      createWatcher(
-        newConfig,
-        factories,
-        queue,
-        processor,
-        logger,
-        runtimeOptions,
-        initialScanTracker,
-        contentHashCache,
-      );
-    newWatcher.start();
-    logger.info('Filesystem watcher rebuilt successfully');
-    return { watcher: newWatcher, gitignoreFilter: newGitignoreFilter };
-  } catch (error) {
-    logger.error(
-      { err: normalizeError(error) },
-      'Failed to rebuild watcher, restoring previous',
-    );
-
-    try {
-      oldState.watcher.start();
-    } catch (restartError) {
-      logger.error(
-        { err: normalizeError(restartError) },
-        'Failed to restart previous watcher',
-      );
-    }
-    return oldState;
-  }
-}
-
-/**
- * Check whether watch-relevant config fields changed between old and new config.
- */
-export function watchConfigChanged(
-  oldConfig: JeevesWatcherConfig,
-  newConfig: JeevesWatcherConfig,
-): boolean {
-  return (
-    JSON.stringify(oldConfig.watch.paths) !==
-      JSON.stringify(newConfig.watch.paths) ||
-    JSON.stringify(oldConfig.watch.ignored) !==
-      JSON.stringify(newConfig.watch.ignored) ||
-    JSON.stringify(oldConfig.watch.moveDetection) !==
-      JSON.stringify(newConfig.watch.moveDetection) ||
-    (oldConfig.watch.respectGitignore ?? true) !==
-      (newConfig.watch.respectGitignore ?? true)
-  );
-}
+// createWatcher, rebuildWatcher, and watchConfigChanged have been moved to watcherFactory.ts.
+// Re-exported here for backward compatibility.
+export {
+  createWatcher,
+  rebuildWatcher,
+  watchConfigChanged,
+  type WatcherState,
+} from './watcherFactory';
 
 /**
  * Resolve package version from nearest package.json.

--- a/packages/service/src/app/watcherFactory.ts
+++ b/packages/service/src/app/watcherFactory.ts
@@ -1,0 +1,144 @@
+/**
+ * @module app/watcherFactory
+ * Factory helpers for creating and rebuilding the filesystem watcher.
+ * Extracted from initialization.ts to follow SRP.
+ */
+
+import { extractWatchPathStrings } from '@karmaniverous/jeeves-watcher-core';
+import type pino from 'pino';
+
+import type { InitialScanTracker } from '../api/InitialScanTracker';
+import type { ContentHashCache } from '../cache';
+import type { JeevesWatcherConfig } from '../config/types';
+import { GitignoreFilter } from '../gitignore';
+import type { DocumentProcessorInterface } from '../processor';
+import type { EventQueue } from '../queue';
+import { normalizeError } from '../util/normalizeError';
+import type { FileSystemWatcher } from '../watcher';
+import type { JeevesWatcherFactories } from './factories';
+
+/** State returned by {@link rebuildWatcher}. */
+export interface WatcherState {
+  watcher: FileSystemWatcher;
+  gitignoreFilter?: GitignoreFilter;
+}
+
+/**
+ * Create file system watcher with gitignore filtering.
+ */
+export function createWatcher(
+  config: JeevesWatcherConfig,
+  factories: JeevesWatcherFactories,
+  queue: EventQueue,
+  processor: DocumentProcessorInterface,
+  logger: pino.Logger,
+  runtimeOptions: {
+    maxRetries?: number;
+    maxBackoffMs?: number;
+    onFatalError?: (error: unknown) => void;
+  },
+  initialScanTracker?: InitialScanTracker,
+  contentHashCache?: ContentHashCache,
+  onVcsFileChange?: (
+    filePath: string,
+    event: 'add' | 'change' | 'unlink',
+  ) => void,
+  onInitialScanComplete?: () => void | Promise<void>,
+): { watcher: FileSystemWatcher; gitignoreFilter?: GitignoreFilter } {
+  const respectGitignore = config.watch.respectGitignore ?? true;
+  const gitignoreFilter = respectGitignore
+    ? new GitignoreFilter(extractWatchPathStrings(config.watch.paths))
+    : undefined;
+
+  const watcher = factories.createFileSystemWatcher(
+    config.watch,
+    queue,
+    processor,
+    logger,
+    {
+      maxRetries: config.maxRetries ?? runtimeOptions.maxRetries,
+      maxBackoffMs: config.maxBackoffMs ?? runtimeOptions.maxBackoffMs,
+      onFatalError: runtimeOptions.onFatalError,
+      gitignoreFilter,
+      initialScanTracker,
+      contentHashCache,
+      onVcsFileChange,
+      onInitialScanComplete,
+    },
+  );
+
+  return { watcher, gitignoreFilter };
+}
+
+/**
+ * Tear down and rebuild the filesystem watcher with new config.
+ * Falls back to the old watcher if the new one fails to start.
+ */
+export async function rebuildWatcher(
+  newConfig: JeevesWatcherConfig,
+  factories: JeevesWatcherFactories,
+  queue: EventQueue,
+  processor: DocumentProcessorInterface,
+  logger: pino.Logger,
+  runtimeOptions: {
+    maxRetries?: number;
+    maxBackoffMs?: number;
+    onFatalError?: (error: unknown) => void;
+  },
+  oldState: WatcherState,
+  initialScanTracker?: InitialScanTracker,
+  contentHashCache?: ContentHashCache,
+): Promise<WatcherState> {
+  try {
+    await oldState.watcher.stop();
+
+    const { watcher: newWatcher, gitignoreFilter: newGitignoreFilter } =
+      createWatcher(
+        newConfig,
+        factories,
+        queue,
+        processor,
+        logger,
+        runtimeOptions,
+        initialScanTracker,
+        contentHashCache,
+      );
+    newWatcher.start();
+    logger.info('Filesystem watcher rebuilt successfully');
+    return { watcher: newWatcher, gitignoreFilter: newGitignoreFilter };
+  } catch (error) {
+    logger.error(
+      { err: normalizeError(error) },
+      'Failed to rebuild watcher, restoring previous',
+    );
+
+    try {
+      oldState.watcher.start();
+    } catch (restartError) {
+      logger.error(
+        { err: normalizeError(restartError) },
+        'Failed to restart previous watcher',
+      );
+    }
+    return oldState;
+  }
+}
+
+/**
+ * Check whether watch-relevant config fields changed between old and new config.
+ */
+export function watchConfigChanged(
+  oldConfig: JeevesWatcherConfig,
+  newConfig: JeevesWatcherConfig,
+): boolean {
+  return (
+    JSON.stringify(oldConfig.watch.paths) !==
+      JSON.stringify(newConfig.watch.paths) ||
+    JSON.stringify(oldConfig.watch.ignored) !==
+      JSON.stringify(newConfig.watch.ignored) ||
+    JSON.stringify(oldConfig.watch.moveDetection) !==
+      JSON.stringify(newConfig.watch.moveDetection) ||
+    (oldConfig.watch.respectGitignore ?? true) !==
+      (newConfig.watch.respectGitignore ?? true)
+  );
+}

--- a/packages/service/src/vcs/CommitMessageBuilder.ts
+++ b/packages/service/src/vcs/CommitMessageBuilder.ts
@@ -1,0 +1,132 @@
+/**
+ * @module vcs/CommitMessageBuilder
+ * Builds commit messages — both template-based and AI-generated.
+ */
+
+import type pino from 'pino';
+
+import { normalizeError } from '../util/normalizeError';
+import type { CommitMessageGenerator } from './CommitMessageGenerator';
+import { execFileAsync } from './gitExec';
+import type { PendingReversion } from './types';
+
+/**
+ * Builds commit messages for VCS commits.
+ * Supports template-based messages and AI-generated messages with fallback.
+ */
+export class CommitMessageBuilder {
+  private readonly rootPath: string;
+  private readonly logger: pino.Logger;
+  private readonly generator: CommitMessageGenerator | undefined;
+
+  constructor(
+    rootPath: string,
+    logger: pino.Logger,
+    generator?: CommitMessageGenerator,
+  ) {
+    this.rootPath = rootPath;
+    this.logger = logger;
+    this.generator = generator;
+  }
+
+  /**
+   * Build the template commit message (no AI).
+   */
+  buildTemplateMessage(
+    fileCount: number,
+    isBaseline: boolean,
+    pendingReversions: readonly PendingReversion[],
+  ): string {
+    if (pendingReversions.length === 0) {
+      if (isBaseline) {
+        return `baseline: batch (${String(fileCount)} files)`;
+      }
+      const timestamp = new Date().toISOString();
+      return `watcher: batch ${timestamp} (${String(fileCount)} files)`;
+    }
+
+    // Count total reverted files across all pending reversions
+    const revertedPaths = new Set(pendingReversions.flatMap((r) => r.paths));
+    const revertedCount = revertedPaths.size;
+    const otherCount = fileCount - revertedCount;
+
+    // Use the first reversion's glob and commit for the message
+    const { glob, commit } = pendingReversions[0];
+    const shortCommit = commit.slice(0, 7);
+
+    let message = `revert: ${glob} to ${shortCommit} — restored ${String(revertedCount)} files`;
+    if (otherCount > 0) {
+      message += ` (+ ${String(otherCount)} other changes)`;
+    }
+
+    return message;
+  }
+
+  /**
+   * Build the commit message, using AI when available with template fallback.
+   */
+  async buildCommitMessage(
+    files: string[],
+    isBaseline: boolean,
+    pendingReversions: readonly PendingReversion[],
+  ): Promise<string> {
+    const fileCount = files.length;
+    const templateMessage = this.buildTemplateMessage(
+      fileCount,
+      isBaseline,
+      pendingReversions,
+    );
+
+    if (!this.generator) {
+      return templateMessage;
+    }
+
+    try {
+      const diffSummary = await this.getStagedDiff();
+      const aiMessage = await this.generator.generate(files, diffSummary);
+
+      if (!aiMessage) {
+        this.logger.warn(
+          'AI commit message generation returned null; using template',
+        );
+        return templateMessage;
+      }
+
+      // For reversions: prefix with revert info + AI description
+      if (pendingReversions.length > 0) {
+        const { glob, commit } = pendingReversions[0];
+        const shortCommit = commit.slice(0, 7);
+        return `revert: ${glob} to ${shortCommit} — ${aiMessage}`;
+      }
+
+      return aiMessage;
+    } catch (error) {
+      this.logger.warn(
+        { err: normalizeError(error) },
+        'AI commit message generation failed; using template',
+      );
+      return templateMessage;
+    }
+  }
+
+  /**
+   * Get the staged diff for AI context.
+   */
+  private async getStagedDiff(): Promise<string> {
+    try {
+      const { stdout: stat } = await execFileAsync(
+        'git',
+        ['diff', '--cached', '--stat'],
+        { cwd: this.rootPath },
+      );
+      const { stdout: patch } = await execFileAsync(
+        'git',
+        ['diff', '--cached'],
+        { cwd: this.rootPath },
+      );
+      return `${stat}\n${patch}`;
+    } catch {
+      return '';
+    }
+  }
+}

--- a/packages/service/src/vcs/VcsCoordinator.test.ts
+++ b/packages/service/src/vcs/VcsCoordinator.test.ts
@@ -77,7 +77,7 @@ describe('VcsCoordinator', () => {
   it('routes file changes to the correct root manager', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    await coordinator.start();
+    coordinator.start();
 
     // Write files to both roots
     const fileA = join(resolve(rootA), 'a.txt');
@@ -105,7 +105,7 @@ describe('VcsCoordinator', () => {
   it('ignores files that do not match any root', async () => {
     const config = makeConfig([rootA]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    await coordinator.start();
+    coordinator.start();
 
     // A file outside all roots — should be silently ignored
     coordinator.onFileChange('/nonexistent/path/file.txt', 'add');
@@ -123,7 +123,7 @@ describe('VcsCoordinator', () => {
     } as unknown as JeevesWatcherConfig;
 
     const coordinator = new VcsCoordinator(config, silentLogger);
-    await coordinator.start();
+    coordinator.start();
 
     const fileA = join(resolve(rootA), 'a.txt');
     await writeFile(fileA, 'content', 'utf8');
@@ -138,7 +138,7 @@ describe('VcsCoordinator', () => {
   it('handles unlink events by staging deletions', async () => {
     const config = makeConfig([rootA]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    await coordinator.start();
+    coordinator.start();
 
     // Create and commit a file first
     const filePath = join(resolve(rootA), 'to-remove.txt');
@@ -172,10 +172,33 @@ describe('VcsCoordinator', () => {
     expect(coordinator.getRoots()).toHaveLength(1);
   });
 
+  it('onInitialScanComplete calls endBaseline on all managers', async () => {
+    const config = makeConfig([rootA, rootB]);
+    const coordinator = new VcsCoordinator(config, silentLogger);
+    coordinator.start();
+
+    // Call onInitialScanComplete to end baseline on all managers
+    coordinator.onInitialScanComplete();
+
+    // After onInitialScanComplete, commits should use normal "watcher: batch" messages
+    const fileA = join(resolve(rootA), 'post-baseline.txt');
+    await writeFile(fileA, 'content after scan', 'utf8');
+    coordinator.onFileChange(fileA, 'add');
+
+    await coordinator.stop();
+
+    // Verify the commit uses normal (not baseline) message
+    const { stdout } = await execFileAsync('git', ['log', '--oneline', '-1'], {
+      cwd: rootA,
+    });
+    expect(stdout).toContain('watcher: batch');
+    expect(stdout).not.toContain('baseline');
+  });
+
   it('stop flushes all pending changes', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    await coordinator.start();
+    coordinator.start();
 
     // Add files to both roots without flushing
     const fileA = join(resolve(rootA), 'pending-a.txt');

--- a/packages/service/src/vcs/VcsCoordinator.test.ts
+++ b/packages/service/src/vcs/VcsCoordinator.test.ts
@@ -178,7 +178,7 @@ describe('VcsCoordinator', () => {
     coordinator.start();
 
     // Call onInitialScanComplete to end baseline on all managers
-    coordinator.onInitialScanComplete();
+    await coordinator.onInitialScanComplete();
 
     // After onInitialScanComplete, commits should use normal "watcher: batch" messages
     const fileA = join(resolve(rootA), 'post-baseline.txt');

--- a/packages/service/src/vcs/VcsCoordinator.ts
+++ b/packages/service/src/vcs/VcsCoordinator.ts
@@ -124,12 +124,17 @@ export class VcsCoordinator {
 
   /**
    * Signal that the initial filesystem scan is complete.
-   * Calls endBaseline() on all managers so subsequent commits use normal messages.
+   *
+   * Flushes each manager's debounce buffer before ending baseline mode, ensuring
+   * any files still pending in the VCS debounce are committed with a
+   * `"baseline:"` prefix rather than `"watcher:"`. AI generation is not enabled
+   * until all managers have completed their flush.
    */
-  onInitialScanComplete(): void {
-    this.managers.forEach((manager) => {
+  async onInitialScanComplete(): Promise<void> {
+    for (const manager of this.managers.values()) {
+      await manager.flush();
       manager.endBaseline();
-    });
+    }
     this.logger.debug('VcsCoordinator: initial scan complete, baseline ended');
   }
 

--- a/packages/service/src/vcs/VcsCoordinator.ts
+++ b/packages/service/src/vcs/VcsCoordinator.ts
@@ -94,12 +94,10 @@ export class VcsCoordinator {
   /**
    * Start all VcsManager instances.
    */
-  async start(): Promise<void> {
-    const startPromises: Promise<void>[] = [];
+  start(): void {
     this.managers.forEach((manager) => {
-      startPromises.push(manager.start());
+      manager.start();
     });
-    await Promise.all(startPromises);
     this.logger.info(
       { rootCount: this.managers.size },
       'VcsCoordinator started',
@@ -122,6 +120,17 @@ export class VcsCoordinator {
     } else {
       manager.fileChanged(normalizedPath);
     }
+  }
+
+  /**
+   * Signal that the initial filesystem scan is complete.
+   * Calls endBaseline() on all managers so subsequent commits use normal messages.
+   */
+  onInitialScanComplete(): void {
+    this.managers.forEach((manager) => {
+      manager.endBaseline();
+    });
+    this.logger.debug('VcsCoordinator: initial scan complete, baseline ended');
   }
 
   /**

--- a/packages/service/src/vcs/VcsManager.test.ts
+++ b/packages/service/src/vcs/VcsManager.test.ts
@@ -70,7 +70,8 @@ describe('VcsManager instance', () => {
   describe('flush', () => {
     it('commits pending files to git', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       const filePath = join(tempDir, 'test.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -97,7 +98,7 @@ describe('VcsManager instance', () => {
       });
 
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       const { stdout: before } = await execFileAsync(
         'git',
@@ -116,7 +117,7 @@ describe('VcsManager instance', () => {
 
     it('handles multiple files in a single commit', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       for (let i = 0; i < 5; i++) {
         const filePath = join(tempDir, `file${String(i)}.txt`);
@@ -138,7 +139,8 @@ describe('VcsManager instance', () => {
   describe('handleUnlink', () => {
     it('stages file deletion in pending set', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       // Create and commit a file first
       const filePath = join(tempDir, 'to-delete.txt');
@@ -175,7 +177,7 @@ describe('VcsManager instance', () => {
 
       const config = makeConfig({ commitDebounceMs: 5000 });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      await manager.start();
+      manager.start();
 
       // Mock flush to avoid real git operations with fake timers
       const flushSpy = vi.spyOn(manager, 'flush').mockResolvedValue(undefined);
@@ -209,7 +211,7 @@ describe('VcsManager instance', () => {
         commitDebounceMs: 60000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      await manager.start();
+      manager.start();
 
       for (let i = 0; i < 3; i++) {
         const filePath = join(tempDir, `file${String(i)}.txt`);
@@ -235,7 +237,7 @@ describe('VcsManager instance', () => {
         commitDebounceMs: 1000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      await manager.start();
+      manager.start();
 
       // Create 3 files — 2 should commit immediately, 1 starts new timer
       for (let i = 0; i < 3; i++) {
@@ -255,7 +257,8 @@ describe('VcsManager instance', () => {
   describe('stop', () => {
     it('flushes pending changes on stop', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       const filePath = join(tempDir, 'stop-test.txt');
       await writeFile(filePath, 'should be committed on stop', 'utf8');
@@ -273,7 +276,7 @@ describe('VcsManager instance', () => {
 
     it('ignores fileChanged calls after stop', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       const file1 = join(tempDir, 'before-stop.txt');
       await writeFile(file1, 'before', 'utf8');
@@ -305,7 +308,8 @@ describe('VcsManager instance', () => {
       const warnSpy = vi.spyOn(logger, 'warn');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       // Create index.lock to simulate contention
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -339,7 +343,7 @@ describe('VcsManager instance', () => {
       const errorSpy = vi.spyOn(logger, 'error');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      await manager.start();
+      manager.start();
 
       // Create index.lock and keep it there
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -363,7 +367,7 @@ describe('VcsManager instance', () => {
       const warnSpy = vi.spyOn(logger, 'warn');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      await manager.start();
+      manager.start();
 
       // Create index.lock to force failure
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -398,7 +402,7 @@ describe('VcsManager instance', () => {
   describe('pendingReversions', () => {
     it('generates revert-prefixed commit message when reversion is pending', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'reverted.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -431,7 +435,7 @@ describe('VcsManager instance', () => {
 
     it('includes other changes count in revert message when mixed', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       // Create initial commit
       const file1 = join(tempDir, 'reverted.txt');
@@ -470,7 +474,7 @@ describe('VcsManager instance', () => {
 
     it('clears pending reversions after commit', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       const file1 = join(tempDir, 'first.txt');
       await writeFile(file1, 'content', 'utf8');
@@ -482,6 +486,9 @@ describe('VcsManager instance', () => {
       });
 
       await manager.flush();
+
+      // End baseline so second commit uses normal message
+      manager.endBaseline();
 
       // Second commit should use normal message
       const file2 = join(tempDir, 'second.txt');
@@ -516,7 +523,8 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       const filePath = join(tempDir, 'ai-test.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -547,7 +555,8 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       const filePath = join(tempDir, 'fallback.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -580,7 +589,8 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       const filePath = join(tempDir, 'error-fallback.txt');
       await writeFile(filePath, 'hello', 'utf8');
@@ -613,7 +623,8 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      await manager.start();
+      manager.start();
+      manager.endBaseline();
 
       const filePath = join(tempDir, 'reverted-ai.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -658,7 +669,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'revert-fallback.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -687,20 +698,16 @@ describe('VcsManager instance', () => {
     });
   });
 
-  describe('baseline commit', () => {
-    it('creates a baseline commit for pre-existing files in an empty repo', async () => {
-      // Do NOT make any initial commits — the repo should be empty
-      const filePath = join(tempDir, 'pre-existing.txt');
-      await writeFile(filePath, 'already here', 'utf8');
+  describe('endBaseline', () => {
+    it('uses baseline message before endBaseline is called', async () => {
+      const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
+      manager.start();
+      // isBaseline starts true — no endBaseline call
 
-      const manager = new VcsManager(
-        tempDir,
-        makeConfig({ commitDebounceMs: 100 }),
-        silentLogger,
-      );
-      await manager.start();
+      const filePath = join(tempDir, 'baseline-file.txt');
+      await writeFile(filePath, 'initial content', 'utf8');
+      manager.fileChanged(filePath);
 
-      // Wait for debounce + commit
       await manager.flush();
 
       expect(await commitCount(tempDir)).toBe(1);
@@ -713,53 +720,20 @@ describe('VcsManager instance', () => {
       expect(stdout).toContain('1 files');
     });
 
-    it('does not create baseline when repo already has commits', async () => {
-      // initRepo already ran in beforeEach; create and commit a file
-      const filePath = join(tempDir, 'existing.txt');
-      await writeFile(filePath, 'content', 'utf8');
-      await execFileAsync('git', ['add', '.'], { cwd: tempDir });
-      await execFileAsync('git', ['commit', '-m', 'initial'], {
-        cwd: tempDir,
-      });
+    it('switches to normal messages after endBaseline is called', async () => {
+      const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
+      manager.start();
 
-      // Create another file that is untracked
-      const filePath2 = join(tempDir, 'untracked.txt');
-      await writeFile(filePath2, 'untracked', 'utf8');
+      const filePath = join(tempDir, 'pre-scan.txt');
+      await writeFile(filePath, 'initial', 'utf8');
+      manager.fileChanged(filePath);
 
-      const manager = new VcsManager(
-        tempDir,
-        makeConfig({ commitDebounceMs: 100 }),
-        silentLogger,
-      );
-      await manager.start();
+      // Signal end of initial scan — clears baseline flag
+      manager.endBaseline();
 
-      // Flush should be a no-op — baseline should not have enqueued
       await manager.flush();
 
-      // Should still be at 1 commit (the initial one)
       expect(await commitCount(tempDir)).toBe(1);
-    });
-
-    it('uses normal commit messages after baseline is done', async () => {
-      // Start with pre-existing file, no commits
-      const filePath = join(tempDir, 'pre-existing.txt');
-      await writeFile(filePath, 'baseline content', 'utf8');
-
-      const manager = new VcsManager(
-        tempDir,
-        makeConfig({ commitDebounceMs: 100 }),
-        silentLogger,
-      );
-      await manager.start();
-      await manager.flush();
-
-      // Now add a second file — should use normal message
-      const filePath2 = join(tempDir, 'new-file.txt');
-      await writeFile(filePath2, 'new content', 'utf8');
-      manager.fileChanged(filePath2);
-      await manager.flush();
-
-      expect(await commitCount(tempDir)).toBe(2);
       const { stdout } = await execFileAsync(
         'git',
         ['log', '--oneline', '-1'],
@@ -769,21 +743,39 @@ describe('VcsManager instance', () => {
       expect(stdout).not.toContain('baseline');
     });
 
-    it('handles empty repo with no untracked files', async () => {
-      const manager = new VcsManager(
-        tempDir,
-        makeConfig({ commitDebounceMs: 100 }),
-        silentLogger,
-      );
-      // tempDir has .gitignore from initRepo but no other untracked files
-      // (actually initRepo just does git init, so it might be empty)
-      await manager.start();
+    it('uses normal message for second commit after endBaseline', async () => {
+      const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
+      manager.start();
+
+      const filePath = join(tempDir, 'first.txt');
+      await writeFile(filePath, 'first', 'utf8');
+      manager.fileChanged(filePath);
       await manager.flush();
 
-      // Should have 0 or 1 commits depending on whether .gitignore exists
-      const count = await commitCount(tempDir);
-      // The initRepo creates .git but no .gitignore, so 0 untracked files
-      expect(count).toBeLessThanOrEqual(1);
+      // First commit used baseline message
+      const { stdout: first } = await execFileAsync(
+        'git',
+        ['log', '--oneline', '-1'],
+        { cwd: tempDir },
+      );
+      expect(first).toContain('baseline: batch');
+
+      // End baseline then add another file
+      manager.endBaseline();
+
+      const filePath2 = join(tempDir, 'second.txt');
+      await writeFile(filePath2, 'second', 'utf8');
+      manager.fileChanged(filePath2);
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(2);
+      const { stdout: second } = await execFileAsync(
+        'git',
+        ['log', '--oneline', '-1'],
+        { cwd: tempDir },
+      );
+      expect(second).toContain('watcher: batch');
+      expect(second).not.toContain('baseline');
     });
   });
 
@@ -808,7 +800,7 @@ describe('VcsManager instance', () => {
         undefined,
         remoteUrl,
       );
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'push-test.txt');
       await writeFile(filePath, 'push content', 'utf8');
@@ -829,7 +821,7 @@ describe('VcsManager instance', () => {
 
     it('does nothing when no remote is configured', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'no-remote.txt');
       await writeFile(filePath, 'no remote', 'utf8');
@@ -852,7 +844,7 @@ describe('VcsManager instance', () => {
         undefined,
         'https://invalid.example.com/nonexistent/repo.git',
       );
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'push-fail.txt');
       await writeFile(filePath, 'will fail push', 'utf8');
@@ -878,7 +870,7 @@ describe('VcsManager instance', () => {
         'https://github.com/test/repo.git',
         'tok/en@special',
       );
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'encode-test.txt');
       await writeFile(filePath, 'content', 'utf8');
@@ -905,7 +897,7 @@ describe('VcsManager instance', () => {
         remoteUrl, // use plain path so push actually works
         'fake-token',
       );
-      await manager.start();
+      manager.start();
 
       const filePath = join(tempDir, 'token-push.txt');
       await writeFile(filePath, 'token push content', 'utf8');

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -8,22 +8,14 @@ import type pino from 'pino';
 
 import { normalizeError } from '../util/normalizeError';
 import { retry } from '../util/retry';
+import { CommitMessageBuilder } from './CommitMessageBuilder';
 import type { CommitMessageGenerator } from './CommitMessageGenerator';
 import { execFileAsync, gitAddViaStdin } from './gitExec';
 import { SquashManager } from './SquashManager';
+import type { PendingReversion, PushError } from './types';
+import { pushToRemote } from './vcsPush';
 
-/** Metadata for a pending reversion to include in the commit message. */
-export interface PendingReversion {
-  glob: string;
-  commit: string;
-  paths: string[];
-}
-
-/** Push error record for status reporting. */
-export interface PushError {
-  timestamp: string;
-  message: string;
-}
+export type { PendingReversion, PushError };
 
 /**
  * Per-root VCS manager for git-backed content versioning.
@@ -41,7 +33,7 @@ export class VcsManager {
   readonly remoteUrl: string | undefined;
   private readonly accessToken: string | undefined;
   private readonly logger: pino.Logger;
-  private readonly commitMessageGenerator: CommitMessageGenerator | undefined;
+  private readonly commitMessageBuilder: CommitMessageBuilder;
   private readonly pending: Set<string> = new Set();
   private readonly pendingReversions: PendingReversion[] = [];
   private readonly _pushErrors: PushError[] = [];
@@ -63,9 +55,14 @@ export class VcsManager {
     this.rootPath = rootPath;
     this.config = config;
     this.logger = logger;
-    this.commitMessageGenerator = commitMessageGenerator;
     this.remoteUrl = remoteUrl;
     this.accessToken = accessToken;
+
+    this.commitMessageBuilder = new CommitMessageBuilder(
+      rootPath,
+      logger,
+      commitMessageGenerator,
+    );
 
     if (config.retention) {
       this.squashManager = new SquashManager(
@@ -87,8 +84,11 @@ export class VcsManager {
   }
 
   /**
-   * Begin accepting file changes. Sets up the debounce mechanism.
-   * Enqueues a baseline commit for pre-existing files if the repo has no commits.
+   * Begin accepting file changes. Sets the manager to started state and
+   * starts the squash manager if configured.
+   *
+   * Baseline mode (commit prefix `"baseline:"`) remains active until
+   * {@link endBaseline} is called by the coordinator after the initial scan.
    */
   start(): void {
     this.started = true;
@@ -212,100 +212,6 @@ export class VcsManager {
   }
 
   /**
-   * Get the cached diff for staged files, for AI context.
-   */
-  private async getStagedDiff(): Promise<string> {
-    try {
-      const { stdout: stat } = await execFileAsync(
-        'git',
-        ['diff', '--cached', '--stat'],
-        { cwd: this.rootPath },
-      );
-      const { stdout: patch } = await execFileAsync(
-        'git',
-        ['diff', '--cached'],
-        { cwd: this.rootPath },
-      );
-      return `${stat}\n${patch}`;
-    } catch {
-      return '';
-    }
-  }
-
-  /**
-   * Build the template commit message (no AI).
-   */
-  private buildTemplateMessage(fileCount: number): string {
-    if (this.pendingReversions.length === 0) {
-      if (this.isBaseline) {
-        return `baseline: batch (${String(fileCount)} files)`;
-      }
-      const timestamp = new Date().toISOString();
-      return `watcher: batch ${timestamp} (${String(fileCount)} files)`;
-    }
-
-    // Count total reverted files across all pending reversions
-    const revertedPaths = new Set(
-      this.pendingReversions.flatMap((r) => r.paths),
-    );
-    const revertedCount = revertedPaths.size;
-    const otherCount = fileCount - revertedCount;
-
-    // Use the first reversion's glob and commit for the message
-    const { glob, commit } = this.pendingReversions[0];
-    const shortCommit = commit.slice(0, 7);
-
-    let message = `revert: ${glob} to ${shortCommit} — restored ${String(revertedCount)} files`;
-    if (otherCount > 0) {
-      message += ` (+ ${String(otherCount)} other changes)`;
-    }
-
-    return message;
-  }
-
-  /**
-   * Build the commit message, using AI when available with template fallback.
-   */
-  private async buildCommitMessage(files: string[]): Promise<string> {
-    const fileCount = files.length;
-    const templateMessage = this.buildTemplateMessage(fileCount);
-
-    if (!this.commitMessageGenerator) {
-      return templateMessage;
-    }
-
-    try {
-      const diffSummary = await this.getStagedDiff();
-      const aiMessage = await this.commitMessageGenerator.generate(
-        files,
-        diffSummary,
-      );
-
-      if (!aiMessage) {
-        this.logger.warn(
-          'AI commit message generation returned null; using template',
-        );
-        return templateMessage;
-      }
-
-      // For reversions: prefix with revert info + AI description
-      if (this.pendingReversions.length > 0) {
-        const { glob, commit } = this.pendingReversions[0];
-        const shortCommit = commit.slice(0, 7);
-        return `revert: ${glob} to ${shortCommit} — ${aiMessage}`;
-      }
-
-      return aiMessage;
-    } catch (error) {
-      this.logger.warn(
-        { err: normalizeError(error) },
-        'AI commit message generation failed; using template',
-      );
-      return templateMessage;
-    }
-  }
-
-  /**
    * Commit a batch of files to the git repo with index.lock retry.
    */
   private async commitBatch(files: string[]): Promise<void> {
@@ -316,12 +222,21 @@ export class VcsManager {
         async (attempt) => {
           await gitAddViaStdin(files, this.rootPath);
 
-          // Build message after staging so getStagedDiff can see the changes
-          // Skip AI for baselines and retries — use template directly
+          // Build message after staging so getStagedDiff can see the changes.
+          // Skip AI for baselines and retries — use template directly.
           const message =
             this.isBaseline || attempt > 1
-              ? this.buildTemplateMessage(files.length)
-              : await this.buildCommitMessage(files);
+              ? this.commitMessageBuilder.buildTemplateMessage(
+                  files.length,
+                  this.isBaseline,
+                  this.pendingReversions,
+                )
+              : await this.commitMessageBuilder.buildCommitMessage(
+                  files,
+                  this.isBaseline,
+                  this.pendingReversions,
+                );
+
           this.pendingReversions.length = 0;
           await execFileAsync('git', ['commit', '-m', message], {
             cwd: this.rootPath,
@@ -337,7 +252,15 @@ export class VcsManager {
             { root: this.rootPath, hash, fileCount: files.length },
             'VCS commit created',
           );
-          await this.pushIfConfigured();
+
+          const pushTime = await pushToRemote(
+            this.rootPath,
+            this.remoteUrl,
+            this.accessToken,
+            this._pushErrors,
+            this.logger,
+          );
+          if (pushTime) this._lastPushTime = pushTime;
         },
         {
           attempts: 4,
@@ -362,45 +285,6 @@ export class VcsManager {
       this.logger.error(
         { root: this.rootPath, err: normalizeError(error) },
         'VCS commit failed',
-      );
-    }
-  }
-
-  /**
-   * Push to the configured remote if remoteUrl is set.
-   * On failure: logs the error and records it in pushErrors; never throws.
-   */
-  private async pushIfConfigured(): Promise<void> {
-    if (!this.remoteUrl) return;
-
-    try {
-      // Build the authenticated URL if a token is available
-      const pushUrl = this.accessToken
-        ? this.remoteUrl.replace(
-            /^https:\/\//,
-            `https://${encodeURIComponent(this.accessToken)}@`,
-          )
-        : this.remoteUrl;
-
-      await execFileAsync('git', ['push', pushUrl, 'HEAD'], {
-        cwd: this.rootPath,
-        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-      });
-
-      this._lastPushTime = new Date().toISOString();
-      this.logger.info(
-        { root: this.rootPath, remote: this.remoteUrl },
-        'VCS push succeeded',
-      );
-    } catch (error) {
-      const pushError: PushError = {
-        timestamp: new Date().toISOString(),
-        message: normalizeError(error).message,
-      };
-      this._pushErrors.push(pushError);
-      this.logger.error(
-        { root: this.rootPath, err: normalizeError(error) },
-        'VCS push failed',
       );
     }
   }

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -49,7 +49,7 @@ export class VcsManager {
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private commitInFlight: Promise<void> = Promise.resolve();
   private started = false;
-  private isBaseline = false;
+  private isBaseline = true;
   private _lastPushTime: string | null = null;
 
   constructor(
@@ -90,59 +90,18 @@ export class VcsManager {
    * Begin accepting file changes. Sets up the debounce mechanism.
    * Enqueues a baseline commit for pre-existing files if the repo has no commits.
    */
-  async start(): Promise<void> {
+  start(): void {
     this.started = true;
     this.squashManager?.start();
     this.logger.info({ root: this.rootPath }, 'VcsManager started');
-
-    await this.enqueueBaselineIfNeeded();
   }
 
   /**
-   * If the repo has no commits, enumerate untracked files and feed them
-   * through fileChanged() to create a baseline commit.
+   * Signal that the initial filesystem scan is complete.
+   * Clears the baseline flag so subsequent commits use normal "watcher: batch" messages.
    */
-  private async enqueueBaselineIfNeeded(): Promise<void> {
-    try {
-      await execFileAsync('git', ['rev-parse', 'HEAD'], {
-        cwd: this.rootPath,
-      });
-      // HEAD exists — repo already has commits
-      return;
-    } catch {
-      // No commits yet — proceed with baseline
-    }
-
-    try {
-      const { stdout } = await execFileAsync(
-        'git',
-        ['ls-files', '--others', '--exclude-standard', '-z'],
-        { cwd: this.rootPath },
-      );
-
-      const files = stdout
-        .split('\0')
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0);
-
-      if (files.length === 0) return;
-
-      this.logger.info(
-        { root: this.rootPath, fileCount: files.length },
-        'Enqueuing baseline commit for pre-existing files',
-      );
-
-      this.isBaseline = true;
-      const absolutePaths = files.map((f) => this.rootPath + '/' + f);
-      for (const filePath of absolutePaths) {
-        this.fileChanged(filePath);
-      }
-    } catch (error) {
-      this.logger.warn(
-        { root: this.rootPath, err: normalizeError(error) },
-        'Failed to enumerate untracked files for baseline commit',
-      );
-    }
+  endBaseline(): void {
+    this.isBaseline = false;
   }
 
   /**
@@ -364,11 +323,6 @@ export class VcsManager {
               ? this.buildTemplateMessage(files.length)
               : await this.buildCommitMessage(files);
           this.pendingReversions.length = 0;
-          // Only clear baseline flag when all baseline files have been committed
-          if (this.pending.size === 0) {
-            this.isBaseline = false;
-          }
-
           await execFileAsync('git', ['commit', '-m', message], {
             cwd: this.rootPath,
           });

--- a/packages/service/src/vcs/index.ts
+++ b/packages/service/src/vcs/index.ts
@@ -3,6 +3,7 @@
  * VCS (version control system) utilities for git-backed content versioning.
  */
 
+export { CommitMessageBuilder } from './CommitMessageBuilder.js';
 export { CommitMessageGenerator } from './CommitMessageGenerator.js';
 export {
   execFileAsync,
@@ -23,6 +24,7 @@ export {
   SquashManager,
   type SquashResult,
 } from './SquashManager.js';
+export { type PendingReversion, type PushError } from './types.js';
 export { validateStateDirOverlap } from './validateStateDirOverlap.js';
 export {
   ALWAYS_GITIGNORE_ENTRIES,
@@ -32,8 +34,5 @@ export {
   initRepo,
 } from './vcsBootstrap.js';
 export { VcsCoordinator } from './VcsCoordinator.js';
-export {
-  type PendingReversion,
-  type PushError,
-  VcsManager,
-} from './VcsManager.js';
+export { VcsManager } from './VcsManager.js';
+export { pushToRemote } from './vcsPush.js';

--- a/packages/service/src/vcs/types.ts
+++ b/packages/service/src/vcs/types.ts
@@ -1,0 +1,17 @@
+/**
+ * @module vcs/types
+ * Shared types for the VCS subsystem.
+ */
+
+/** Metadata for a pending reversion to include in the commit message. */
+export interface PendingReversion {
+  glob: string;
+  commit: string;
+  paths: string[];
+}
+
+/** Push error record for status reporting. */
+export interface PushError {
+  timestamp: string;
+  message: string;
+}

--- a/packages/service/src/vcs/vcsPush.ts
+++ b/packages/service/src/vcs/vcsPush.ts
@@ -1,0 +1,63 @@
+/**
+ * @module vcs/vcsPush
+ * Push logic for VCS commits.
+ */
+
+import type pino from 'pino';
+
+import { normalizeError } from '../util/normalizeError';
+import { execFileAsync } from './gitExec';
+import type { PushError } from './types';
+
+/**
+ * Push to the configured remote if remoteUrl is set.
+ *
+ * On failure: logs the error, appends to pushErrors, and returns undefined.
+ * Never throws.
+ *
+ * @param rootPath - Absolute path of the git repository.
+ * @param remoteUrl - Remote URL to push to, or undefined to skip.
+ * @param accessToken - Optional token for HTTPS authentication.
+ * @param pushErrors - Mutable array where push errors are recorded.
+ * @param logger - Logger instance.
+ * @returns ISO timestamp of a successful push, or undefined if skipped/failed.
+ */
+export async function pushToRemote(
+  rootPath: string,
+  remoteUrl: string | undefined,
+  accessToken: string | undefined,
+  pushErrors: PushError[],
+  logger: pino.Logger,
+): Promise<string | undefined> {
+  if (!remoteUrl) return undefined;
+
+  try {
+    // Build the authenticated URL if a token is available
+    const pushUrl = accessToken
+      ? remoteUrl.replace(
+          /^https:\/\//,
+          `https://${encodeURIComponent(accessToken)}@`,
+        )
+      : remoteUrl;
+
+    await execFileAsync('git', ['push', pushUrl, 'HEAD'], {
+      cwd: rootPath,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+
+    const timestamp = new Date().toISOString();
+    logger.info({ root: rootPath, remote: remoteUrl }, 'VCS push succeeded');
+    return timestamp;
+  } catch (error) {
+    const pushError: PushError = {
+      timestamp: new Date().toISOString(),
+      message: normalizeError(error).message,
+    };
+    pushErrors.push(pushError);
+    logger.error(
+      { root: rootPath, err: normalizeError(error) },
+      'VCS push failed',
+    );
+    return undefined;
+  }
+}

--- a/packages/service/src/watcher/ScanStats.ts
+++ b/packages/service/src/watcher/ScanStats.ts
@@ -1,0 +1,33 @@
+/**
+ * @module watcher/ScanStats
+ * Tracks initial filesystem scan statistics for diagnostics.
+ */
+
+/**
+ * Mutable counter bag updated during the chokidar initial scan.
+ * Extracted from the watcher start() method for clarity.
+ */
+export class ScanStats {
+  total = 0;
+  matched = 0;
+  globRejected = 0;
+  gitignored = 0;
+  readonly byRoot: Record<string, number>;
+
+  constructor(roots: string[]) {
+    this.byRoot = Object.fromEntries(roots.map((r) => [r, 0]));
+  }
+
+  /**
+   * Attribute a newly discovered file to its root for per-root diagnostics.
+   */
+  classifyByRoot(path: string): void {
+    const normalized = path.replace(/\\/g, '/').toLowerCase();
+    for (const root of Object.keys(this.byRoot)) {
+      if (normalized.startsWith(`${root}/`) || normalized === root) {
+        this.byRoot[root] = (this.byRoot[root] ?? 0) + 1;
+        break;
+      }
+    }
+  }
+}

--- a/packages/service/src/watcher/index.ts
+++ b/packages/service/src/watcher/index.ts
@@ -18,6 +18,7 @@ import type { EventQueue } from '../queue';
 import { normalizeError } from '../util/normalizeError';
 import { resolveIgnored, resolveWatchPaths } from './globToDir';
 import { MoveCorrelator } from './MoveCorrelator';
+import { ScanStats } from './ScanStats';
 
 /**
  * Options for {@link FileSystemWatcher} beyond basic config.
@@ -41,7 +42,7 @@ export interface FileSystemWatcherOptions {
     event: 'add' | 'change' | 'unlink',
   ) => void;
   /** Optional callback invoked when the initial filesystem scan completes. */
-  onInitialScanComplete?: () => void;
+  onInitialScanComplete?: () => void | Promise<void>;
 }
 
 /**
@@ -60,7 +61,7 @@ export class FileSystemWatcher {
     filePath: string,
     event: 'add' | 'change' | 'unlink',
   ) => void;
-  private readonly onInitialScanComplete?: () => void;
+  private readonly onInitialScanComplete?: () => void | Promise<void>;
   private moveCorrelator?: MoveCorrelator;
   private globMatches: (filePath: string) => boolean;
   private watcher: FSWatcher | undefined;
@@ -124,28 +125,9 @@ export class FileSystemWatcher {
       : undefined;
 
     // Track initial scan statistics per root for diagnostics.
-    const scanStats = {
-      total: 0,
-      matched: 0,
-      globRejected: 0,
-      gitignored: 0,
-      byRoot: Object.fromEntries(roots.map((r) => [r, 0])) as Record<
-        string,
-        number
-      >,
-    };
+    const scanStats = new ScanStats(roots);
     let initialScanComplete = false;
     this.initialScanTracker?.start();
-
-    const classifyByRoot = (path: string): void => {
-      const normalized = path.replace(/\\/g, '/').toLowerCase();
-      for (const root of roots) {
-        if (normalized.startsWith(root + '/') || normalized === root) {
-          scanStats.byRoot[root] = (scanStats.byRoot[root] ?? 0) + 1;
-          break;
-        }
-      }
-    };
 
     // Create move correlator if move detection is configured and cache is available.
     const moveConfig = this.config.moveDetection;
@@ -198,7 +180,7 @@ export class FileSystemWatcher {
     this.watcher.on('add', (path: string) => {
       if (!initialScanComplete) {
         scanStats.total++;
-        classifyByRoot(path);
+        scanStats.classifyByRoot(path);
       }
       this.handleGitignoreChange(path);
       if (!this.globMatches(path)) {
@@ -259,7 +241,7 @@ export class FileSystemWatcher {
       initialScanComplete = true;
       this.initialScanTracker?.complete();
       this.logger.info({ scanStats }, 'Initial scan complete');
-      this.onInitialScanComplete?.();
+      void this.onInitialScanComplete?.();
     });
 
     this.watcher.on('error', (error: unknown) => {

--- a/packages/service/src/watcher/index.ts
+++ b/packages/service/src/watcher/index.ts
@@ -40,6 +40,8 @@ export interface FileSystemWatcherOptions {
     filePath: string,
     event: 'add' | 'change' | 'unlink',
   ) => void;
+  /** Optional callback invoked when the initial filesystem scan completes. */
+  onInitialScanComplete?: () => void;
 }
 
 /**
@@ -58,6 +60,7 @@ export class FileSystemWatcher {
     filePath: string,
     event: 'add' | 'change' | 'unlink',
   ) => void;
+  private readonly onInitialScanComplete?: () => void;
   private moveCorrelator?: MoveCorrelator;
   private globMatches: (filePath: string) => boolean;
   private watcher: FSWatcher | undefined;
@@ -87,6 +90,7 @@ export class FileSystemWatcher {
     this.initialScanTracker = options.initialScanTracker;
     this.contentHashCache = options.contentHashCache;
     this.onVcsFileChange = options.onVcsFileChange;
+    this.onInitialScanComplete = options.onInitialScanComplete;
     this.globMatches = () => true;
 
     const healthOptions: SystemHealthOptions = {
@@ -212,7 +216,7 @@ export class FileSystemWatcher {
         this.initialScanTracker?.incrementEnqueued();
       }
       this.logger.debug({ path }, 'File added');
-      if (initialScanComplete) this.onVcsFileChange?.(path, 'add');
+      this.onVcsFileChange?.(path, 'add');
       if (correlator && initialScanComplete) {
         void correlator.handleAdd(path);
       } else {
@@ -255,6 +259,7 @@ export class FileSystemWatcher {
       initialScanComplete = true;
       this.initialScanTracker?.complete();
       this.logger.info({ scanStats }, 'Initial scan complete');
+      this.onInitialScanComplete?.();
     });
 
     this.watcher.on('error', (error: unknown) => {


### PR DESCRIPTION
Fixes #214

## Problem

`enqueueBaselineIfNeeded()` in `VcsManager` independently enumerates untracked files via `git ls-files --others --exclude-standard` using `execFileAsync` (Node's `promisify(execFile)`), which has a default `maxBuffer` of 1 MB. Watch roots with >1 MB of file path output (e.g. 60K+ files) silently fail their baseline — the error is caught and logged as a warning, but the root is left with zero commits.

**Observed in prod:**
- `j:/veterancrowd` (60,608 files, 3.83 MB output): baseline never ran
- `j:/domains` (135,925 files, 7.9 MB output): baseline failed

## Fix

Eliminate the redundant file enumeration entirely. VCS now piggybacks on chokidar's initial scan events:

1. **Remove `enqueueBaselineIfNeeded()`** — VCS no longer independently enumerates files
2. **Remove `if (initialScanComplete)` guard** on VCS in the chokidar `add` handler — initial scan `add` events now flow to VCS directly
3. **Add `onInitialScanComplete` signal** from the watcher to VcsCoordinator, which calls `endBaseline()` on all managers to transition commit messages from "baseline:" to "watcher:" format

This ensures VCS coverage is identical to embedding coverage — same glob filters, same gitignore filtering, single source of truth for file discovery.

## Changes

- `packages/service/src/vcs/VcsManager.ts` — removed `enqueueBaselineIfNeeded()`, added `endBaseline()`, baseline mode defaults to `true`
- `packages/service/src/vcs/VcsCoordinator.ts` — added `onInitialScanComplete()`
- `packages/service/src/watcher/index.ts` — removed `initialScanComplete` guard on VCS, added `onInitialScanComplete` callback
- `packages/service/src/app/initialization.ts` — wired `onInitialScanComplete` through `createWatcher`
- `packages/service/src/app/index.ts` — connected callback to VcsCoordinator
- Tests updated: 726 passing
