### PR TITLE
fix: VCS throttle + shared endpoint catalog (#221, #196)

### DIFF
--- a/packages/core/src/defaults.ts
+++ b/packages/core/src/defaults.ts
@@ -43,7 +43,7 @@ export const WATCH_DEFAULTS = {
 /** Default VCS configuration. */
 export const VCS_DEFAULTS = {
   enabled: false,
-  commitDebounceMs: 30000,
+  commitThrottleMs: 30000,
   maxBatchSize: 1000,
   commitMessage: {
     enabled: true,

--- a/packages/core/src/endpoints.test.ts
+++ b/packages/core/src/endpoints.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getEndpoint,
+  WATCHER_ENDPOINTS,
+  type EndpointName,
+} from './endpoints';
+
+describe('endpoint catalog', () => {
+  it('contains at least one endpoint', () => {
+    expect(WATCHER_ENDPOINTS.length).toBeGreaterThan(0);
+  });
+
+  it('has unique names', () => {
+    const names = WATCHER_ENDPOINTS.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('has unique path+method combinations', () => {
+    const keys = WATCHER_ENDPOINTS.map((e) => `${e.method} ${e.path}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('getEndpoint returns correct descriptor for each name', () => {
+    for (const ep of WATCHER_ENDPOINTS) {
+      const result = getEndpoint(ep.name as EndpointName);
+      expect(result).toBe(ep);
+    }
+  });
+
+  it('getEndpoint throws for unknown name', () => {
+    expect(() => getEndpoint('nonexistent' as EndpointName)).toThrow(
+      'Unknown endpoint: nonexistent',
+    );
+  });
+
+  it('every endpoint has non-empty description', () => {
+    for (const ep of WATCHER_ENDPOINTS) {
+      expect(ep.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every endpoint path starts with /', () => {
+    for (const ep of WATCHER_ENDPOINTS) {
+      expect(ep.path).toMatch(/^\//);
+    }
+  });
+});

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -1,0 +1,225 @@
+/**
+ * Shared endpoint catalog — single source of truth for the jeeves-watcher API.
+ *
+ * Both the CLI service and the OpenClaw plugin derive their registrations
+ * from this declarative catalog, eliminating drift between the two.
+ *
+ */
+
+/** HTTP methods used by the API. */
+export type HttpMethod = 'DELETE' | 'GET' | 'POST';
+
+/** Descriptor for a single API endpoint. */
+export interface EndpointDescriptor {
+  /** Unique endpoint identifier (camelCase). */
+  name: string;
+  /** HTTP method. */
+  method: HttpMethod;
+  /** URL path pattern (e.g. '/search'). */
+  path: string;
+  /** Human-readable description of the endpoint's purpose. */
+  description: string;
+}
+
+/**
+ * Canonical endpoint catalog for the jeeves-watcher API.
+ *
+ * Every entry describes a single HTTP endpoint exposed by the service.
+ * Route handlers, plugin tools, and HTTP clients should reference these
+ * descriptors rather than hard-coding paths and descriptions.
+ */
+export const WATCHER_ENDPOINTS = [
+  {
+    name: 'status',
+    method: 'GET',
+    path: '/status',
+    description: 'Service health and status overview.',
+  },
+  {
+    name: 'metadata',
+    method: 'POST',
+    path: '/metadata',
+    description: 'Set or update metadata on a document by file path.',
+  },
+  {
+    name: 'render',
+    method: 'POST',
+    path: '/render',
+    description: 'Render a document through the template pipeline.',
+  },
+  {
+    name: 'searchFacets',
+    method: 'GET',
+    path: '/search/facets',
+    description: 'List available search facets and their values.',
+  },
+  {
+    name: 'scan',
+    method: 'POST',
+    path: '/scan',
+    description:
+      'Filter-only point query without vector search. Returns metadata for points matching a Qdrant filter.',
+  },
+  {
+    name: 'walk',
+    method: 'POST',
+    path: '/walk',
+    description:
+      'Walk watched filesystem paths with glob intersection. Returns matching file paths.',
+  },
+  {
+    name: 'search',
+    method: 'POST',
+    path: '/search',
+    description:
+      'Semantic search over indexed documents. Supports Qdrant filters.',
+  },
+  {
+    name: 'rebuildMetadata',
+    method: 'POST',
+    path: '/rebuild-metadata',
+    description: 'Rebuild metadata from enrichment store into vector points.',
+  },
+  {
+    name: 'reindex',
+    method: 'POST',
+    path: '/reindex',
+    description: 'Trigger a scoped reindex of watched files.',
+  },
+  {
+    name: 'issues',
+    method: 'GET',
+    path: '/issues',
+    description:
+      'Get runtime embedding failures. Shows files that failed processing and why.',
+  },
+  {
+    name: 'configSchema',
+    method: 'GET',
+    path: '/config/schema',
+    description: 'Get the JSON Schema for the configuration file.',
+  },
+  {
+    name: 'configMatch',
+    method: 'POST',
+    path: '/config/match',
+    description: 'Test file paths against config inference rules.',
+  },
+  {
+    name: 'config',
+    method: 'GET',
+    path: '/config',
+    description: 'Query service configuration with optional JSONPath.',
+  },
+  {
+    name: 'configValidate',
+    method: 'POST',
+    path: '/config/validate',
+    description:
+      'Validate a candidate config. Optionally test file paths against the config.',
+  },
+  {
+    name: 'configApply',
+    method: 'POST',
+    path: '/config/apply',
+    description: 'Apply a configuration patch.',
+  },
+  {
+    name: 'rulesRegister',
+    method: 'POST',
+    path: '/rules/register',
+    description: 'Register external inference rules.',
+  },
+  {
+    name: 'rulesUnregister',
+    method: 'DELETE',
+    path: '/rules/unregister',
+    description: 'Unregister external inference rules.',
+  },
+  {
+    name: 'rulesUnregisterBySource',
+    method: 'DELETE',
+    path: '/rules/unregister/:source',
+    description: 'Unregister all external inference rules from a source.',
+  },
+  {
+    name: 'pointsDelete',
+    method: 'POST',
+    path: '/points/delete',
+    description: 'Delete points from the vector store by filter.',
+  },
+  {
+    name: 'rulesReapply',
+    method: 'POST',
+    path: '/rules/reapply',
+    description: 'Re-apply inference rules to existing vector points.',
+  },
+  {
+    name: 'vcsStatus',
+    method: 'GET',
+    path: '/vcs/status',
+    description:
+      'VCS state for all roots: enabled state, tracked files, last commit, remote status.',
+  },
+  {
+    name: 'vcsHistory',
+    method: 'GET',
+    path: '/vcs/history',
+    description:
+      'Query change history by path or glob with optional date range.',
+  },
+  {
+    name: 'vcsShow',
+    method: 'GET',
+    path: '/vcs/show',
+    description: 'Retrieve file content at a specific version.',
+  },
+  {
+    name: 'vcsDiff',
+    method: 'GET',
+    path: '/vcs/diff',
+    description:
+      'Show what changed between two versions, or between a version and current.',
+  },
+  {
+    name: 'vcsCheckExclusion',
+    method: 'GET',
+    path: '/vcs/check-exclusion',
+    description:
+      'Check whether a path is excluded from version tracking and why.',
+  },
+  {
+    name: 'vcsRevert',
+    method: 'POST',
+    path: '/vcs/revert',
+    description:
+      'Restore files from a historical commit (forward-only reversion).',
+  },
+  {
+    name: 'vcsExclude',
+    method: 'POST',
+    path: '/vcs/exclude',
+    description: 'Manage .gitignore entries for version tracking exclusion.',
+  },
+] as const satisfies readonly EndpointDescriptor[];
+
+/** Union of all endpoint names. */
+export type EndpointName = (typeof WATCHER_ENDPOINTS)[number]['name'];
+
+/** Single entry from the catalog, narrowed by name. */
+export type Endpoint<N extends EndpointName> = Extract<
+  (typeof WATCHER_ENDPOINTS)[number],
+  { name: N }
+>;
+
+/**
+ * Look up an endpoint descriptor by name.
+ *
+ * @param name - The endpoint identifier.
+ * @returns The matching {@link EndpointDescriptor}.
+ */
+export function getEndpoint<N extends EndpointName>(name: N): Endpoint<N> {
+  const ep = WATCHER_ENDPOINTS.find((e) => e.name === name);
+  if (!ep) throw new Error(`Unknown endpoint: ${name}`);
+  return ep as Endpoint<N>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,14 @@ export {
   WATCH_DEFAULTS,
 } from './defaults.js';
 export {
+  type Endpoint,
+  type EndpointDescriptor,
+  type EndpointName,
+  getEndpoint,
+  type HttpMethod,
+  WATCHER_ENDPOINTS,
+} from './endpoints.js';
+export {
   type ApiConfig,
   apiConfigSchema,
   type ConfigWatchConfig,

--- a/packages/core/src/schemas/vcs.test.ts
+++ b/packages/core/src/schemas/vcs.test.ts
@@ -18,7 +18,7 @@ describe('vcsConfigSchema', () => {
   it('applies defaults for all fields', () => {
     const result = vcsConfigSchema.parse({});
     expect(result.enabled).toBe(false);
-    expect(result.commitDebounceMs).toBe(30000);
+    expect(result.commitThrottleMs).toBe(30000);
     expect(result.maxBatchSize).toBe(1000);
   });
 
@@ -40,7 +40,7 @@ describe('vcsConfigSchema', () => {
   it('accepts full custom config', () => {
     const result = vcsConfigSchema.safeParse({
       enabled: true,
-      commitDebounceMs: 5000,
+      commitThrottleMs: 5000,
       maxBatchSize: 500,
       commitMessage: {
         enabled: false,
@@ -58,8 +58,8 @@ describe('vcsConfigSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects invalid commitDebounceMs', () => {
-    const result = vcsConfigSchema.safeParse({ commitDebounceMs: 500 });
+  it('rejects invalid commitThrottleMs', () => {
+    const result = vcsConfigSchema.safeParse({ commitThrottleMs: 500 });
     expect(result.success).toBe(false);
   });
 

--- a/packages/core/src/schemas/vcs.ts
+++ b/packages/core/src/schemas/vcs.ts
@@ -110,14 +110,14 @@ export const vcsConfigSchema = z.object({
     .describe(
       'Git commit author identity. Set per-repo during init. Defaults: name="jeeves-watcher", email="watcher@localhost".',
     ),
-  /** Debounce interval in milliseconds for batching commits. */
-  commitDebounceMs: z
+  /** Throttle interval in milliseconds for batching commits. */
+  commitThrottleMs: z
     .number()
     .int()
     .min(1000)
     .default(30000)
     .describe(
-      'Debounce interval in milliseconds for batching commits. Default: 30000.',
+      'Throttle interval in milliseconds for batching commits. Default: 30000.',
     ),
   /** Maximum number of files per commit batch. */
   maxBatchSize: z

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from '@karmaniverous/jeeves';
+import { getEndpoint } from '@karmaniverous/jeeves-watcher-core';
 
 import { MENU_FETCH_TIMEOUT_MS } from './constants.js';
 
@@ -37,14 +38,16 @@ export async function generateWatcherMenu(apiUrl: string): Promise<string> {
   const fetchOpts = { signal: AbortSignal.timeout(MENU_FETCH_TIMEOUT_MS) };
 
   const [statusRes, thresholdsRes, vcsRes] = (await Promise.all([
-    fetchJson(`${apiUrl}/status`, fetchOpts),
+    fetchJson(`${apiUrl}${getEndpoint('status').path}`, fetchOpts),
     fetchJson(
-      `${apiUrl}/config?path=${encodeURIComponent('$.search.scoreThresholds')}`,
+      `${apiUrl}${getEndpoint('config').path}?path=${encodeURIComponent('$.search.scoreThresholds')}`,
       fetchOpts,
     ),
-    fetchJson(`${apiUrl}/vcs/status`, fetchOpts).catch(() => ({
-      enabled: false,
-    })),
+    fetchJson(`${apiUrl}${getEndpoint('vcsStatus').path}`, fetchOpts).catch(
+      () => ({
+        enabled: false,
+      }),
+    ),
   ])) as [
     StatusResponse,
     QueryResponse<Record<string, unknown>>,

--- a/packages/openclaw/src/watcherTools.ts
+++ b/packages/openclaw/src/watcherTools.ts
@@ -11,6 +11,7 @@ import {
   postJson,
   type ToolResult,
 } from '@karmaniverous/jeeves';
+import { getEndpoint } from '@karmaniverous/jeeves-watcher-core';
 
 import { PLUGIN_ID } from './constants.js';
 
@@ -107,7 +108,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
           'offset',
           'filter',
         ]);
-        return ['/search', body];
+        return [getEndpoint('search').path, body];
       },
     },
     {
@@ -128,7 +129,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => [
-        '/metadata',
+        getEndpoint('metadata').path,
         { path: params.path, metadata: params.metadata },
       ],
     },
@@ -154,7 +155,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
       },
       buildRequest: (params) => {
         const body = pickDefined(params, ['config', 'testPaths']);
-        return ['/config/validate', body];
+        return [getEndpoint('configValidate').path, body];
       },
     },
     {
@@ -185,7 +186,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => [
-        '/reindex',
+        getEndpoint('reindex').path,
         {
           scope: params.scope ?? 'rules',
           ...(params.path ? { path: params.path } : {}),
@@ -232,7 +233,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
           'fields',
           'countOnly',
         ]);
-        return ['/scan', body];
+        return [getEndpoint('scan').path, body];
       },
     },
     {
@@ -240,7 +241,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
       description:
         'Get runtime embedding failures. Shows files that failed processing and why.',
       parameters: { type: 'object', properties: {} },
-      buildRequest: () => ['/issues'],
+      buildRequest: () => [getEndpoint('issues').path],
     },
     {
       name: 'watcher_walk',
@@ -258,7 +259,10 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
           },
         },
       },
-      buildRequest: (params) => ['/walk', { globs: params.globs }],
+      buildRequest: (params) => [
+        getEndpoint('walk').path,
+        { globs: params.globs },
+      ],
     },
 
     // ── VCS tools ──────────────────────────────────────────────────────
@@ -268,7 +272,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
       description:
         'Get version tracking health: enabled state, tracked roots, remote status, last activity',
       parameters: { type: 'object', properties: {} },
-      buildRequest: () => ['/vcs/status'],
+      buildRequest: () => [getEndpoint('vcsStatus').path],
     },
     {
       name: 'watcher_vcs_history',
@@ -297,7 +301,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => [
-        `/vcs/history${buildQuery(params, ['glob', 'since', 'until', 'limit'])}`,
+        `${getEndpoint('vcsHistory').path}${buildQuery(params, ['glob', 'since', 'until', 'limit'])}`,
       ],
     },
     {
@@ -318,7 +322,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => [
-        `/vcs/show${buildQuery(params, ['path', 'commit'])}`,
+        `${getEndpoint('vcsShow').path}${buildQuery(params, ['path', 'commit'])}`,
       ],
     },
     {
@@ -345,7 +349,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => [
-        `/vcs/diff${buildQuery(params, ['glob', 'commit', 'commitEnd'])}`,
+        `${getEndpoint('vcsDiff').path}${buildQuery(params, ['glob', 'commit', 'commitEnd'])}`,
       ],
     },
     {
@@ -372,7 +376,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
       },
       buildRequest: (params) => {
         const body = pickDefined(params, ['glob', 'commit', 'existingOnly']);
-        return ['/vcs/revert', body];
+        return [getEndpoint('vcsRevert').path, body];
       },
     },
     {
@@ -399,7 +403,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
       },
       buildRequest: (params) => {
         const body = pickDefined(params, ['glob', 'root', 'remove']);
-        return ['/vcs/exclude', body];
+        return [getEndpoint('vcsExclude').path, body];
       },
     },
     {
@@ -417,7 +421,7 @@ export function registerWatcherTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => [
-        `/vcs/check-exclusion${buildQuery(params, ['path'])}`,
+        `${getEndpoint('vcsCheckExclusion').path}${buildQuery(params, ['path'])}`,
       ],
     },
   ];

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -29,7 +29,7 @@ Add a `vcs` block to your config:
 {
   "vcs": {
     "enabled": true,
-    "commitDebounceMs": 30000,
+    "commitThrottleMs": 30000,
     "maxBatchSize": 1000,
     "commitMessage": {
       "enabled": true,
@@ -50,7 +50,7 @@ Add a `vcs` block to your config:
 | Property | Default | Description |
 |----------|---------|-------------|
 | `vcs.enabled` | `false` | Enable git-backed version control globally |
-| `vcs.commitDebounceMs` | `30000` | Debounce interval (ms) for batching file changes into commits. Min: 1000 |
+| `vcs.commitThrottleMs` | `30000` | Throttle interval (ms) for batching file changes into commits. Min: 1000 |
 | `vcs.maxBatchSize` | `1000` | Maximum files per commit batch. Flushes immediately when exceeded. Min: 1 |
 | `vcs.commitMessage.enabled` | `true` | Enable AI-generated commit messages |
 | `vcs.commitMessage.provider` | `"anthropic"` | AI provider (currently only `"anthropic"` supported) |

--- a/packages/service/config.schema.json
+++ b/packages/service/config.schema.json
@@ -338,7 +338,7 @@
             }
           ]
         },
-        "commitDebounceMs": {
+        "commitThrottleMs": {
           "allOf": [
             {
               "$ref": "#/definitions/__schema14"
@@ -458,7 +458,7 @@
     },
     "__schema14": {
       "default": 30000,
-      "description": "Debounce interval in milliseconds for batching commits. Default: 30000.",
+      "description": "Throttle interval in milliseconds for batching commits. Default: 30000.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema15"
@@ -1487,7 +1487,7 @@
         "author": {
           "$ref": "#/definitions/__schema10"
         },
-        "commitDebounceMs": {
+        "commitThrottleMs": {
           "$ref": "#/definitions/__schema14"
         },
         "maxBatchSize": {

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -647,7 +647,7 @@ On shutdown, the watcher:
 {
   "vcs": {
     "enabled": true,
-    "commitDebounceMs": 30000,
+    "commitThrottleMs": 30000,
     "maxBatchSize": 1000,
     "commitMessage": {
       "enabled": true,
@@ -670,7 +670,7 @@ On shutdown, the watcher:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Enable git-backed content versioning. |
-| `commitDebounceMs` | `number` | `30000` | Debounce window (ms) before committing (min: 1000). |
+| `commitThrottleMs` | `number` | `30000` | Throttle interval (ms) for batching commits (min: 1000). |
 | `maxBatchSize` | `number` | `1000` | Max files per commit batch (min: 1). |
 | `commitMessage.enabled` | `boolean` | `true` | Enable AI-generated commit messages. |
 | `commitMessage.provider` | `string` | `"anthropic"` | LLM provider. |

--- a/packages/service/guides/version-control.md
+++ b/packages/service/guides/version-control.md
@@ -4,7 +4,7 @@ title: Version Control (VCS)
 
 # Version Control (VCS)
 
-Git-backed versioning of watched content. The VCS subsystem maintains a forward-only history of file changes in each watch root, with debounced batch commits, AI-generated commit messages, squash retention, and optional remote push.
+Git-backed versioning of watched content. The VCS subsystem maintains a forward-only history of file changes in each watch root, with throttled batch commits, AI-generated commit messages, squash retention, and optional remote push.
 
 Git terminology is used throughout — this is an operator-facing feature.
 
@@ -16,12 +16,12 @@ Git terminology is used throughout — this is an operator-facing feature.
 
 Each watch path gets its own git repository, initialized automatically at startup. This keeps histories isolated — a revert in one root never affects another.
 
-### Debounced Batch Commits
+### Throttled Batch Commits
 
 File changes are collected into batches rather than committed individually. The commit pipeline uses two controls:
 
-- **`commitDebounceMs`** (default: 30000) — After the last file change, wait this long before committing. Resets on each new change.
-- **`maxBatchSize`** (default: 1000) — If the pending set reaches this size, flush immediately without waiting for the debounce timer. Overflow files roll into the next commit cycle.
+- **`commitThrottleMs`** (default: 30000) — After the first file change, wait this long before committing. New changes during the interval are batched but do not reset the timer.
+- **`maxBatchSize`** (default: 1000) — If the pending set reaches this size, flush immediately without waiting for the throttle timer. Overflow files roll into the next commit cycle.
 
 ### Forward-Only Reversion
 
@@ -41,7 +41,7 @@ VCS tracking and watcher embedding are independent concerns. Git can track files
 {
   "vcs": {
     "enabled": true,
-    "commitDebounceMs": 30000,
+    "commitThrottleMs": 30000,
     "maxBatchSize": 1000,
     "commitMessage": {
       "enabled": true,
@@ -64,7 +64,7 @@ VCS tracking and watcher embedding are independent concerns. Git can track files
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Enable VCS tracking globally. |
-| `commitDebounceMs` | `number` | `30000` | Milliseconds to wait after last file change before committing (min: 1000). |
+| `commitThrottleMs` | `number` | `30000` | Throttle interval in milliseconds for batching commits (min: 1000). Timer starts on first change and does not reset. |
 | `maxBatchSize` | `number` | `1000` | Max files per commit batch (min: 1). Overflow rolls to next cycle. |
 | `commitMessage` | `object` | See below | AI commit message generation settings. |
 | `commitMessage.enabled` | `boolean` | `true` | Enable AI-generated commit messages. Falls back to template on failure. |
@@ -93,7 +93,7 @@ Watch paths can override any VCS setting and add root-specific `remote` and `acc
           "enabled": true,
           "remote": "https://github.com/org/docs-backup.git",
           "accessToken": "${DOCS_GIT_TOKEN}",
-          "commitDebounceMs": 10000,
+          "commitThrottleMs": 10000,
           "maxBatchSize": 500
         }
       },

--- a/packages/service/src/api/handlers/vcs/vcs.test.ts
+++ b/packages/service/src/api/handlers/vcs/vcs.test.ts
@@ -76,7 +76,7 @@ describe('VCS API handlers', () => {
     });
 
     const config = {
-      vcs: { enabled: true, commitDebounceMs: 60000, maxBatchSize: 1000 },
+      vcs: { enabled: true, commitThrottleMs: 60000, maxBatchSize: 1000 },
       watch: { paths: [rootA], ignored: [] },
     } as unknown as JeevesWatcherConfig;
     coordinator = new VcsCoordinator(config, silentLogger);
@@ -125,7 +125,7 @@ describe('VCS API handlers', () => {
 
     it('returns enabled:false when no VCS roots exist', async () => {
       const emptyConfig = {
-        vcs: { enabled: false, commitDebounceMs: 5000, maxBatchSize: 1000 },
+        vcs: { enabled: false, commitThrottleMs: 5000, maxBatchSize: 1000 },
         watch: { paths: [], ignored: [] },
       } as unknown as JeevesWatcherConfig;
       const emptyCoordinator = new VcsCoordinator(emptyConfig, silentLogger);

--- a/packages/service/src/api/index.ts
+++ b/packages/service/src/api/index.ts
@@ -10,7 +10,10 @@ import {
   createStatusHandler as coreCreateStatusHandler,
   type JeevesComponentDescriptor,
 } from '@karmaniverous/jeeves';
-import { extractWatchPathStrings } from '@karmaniverous/jeeves-watcher-core';
+import {
+  extractWatchPathStrings,
+  getEndpoint,
+} from '@karmaniverous/jeeves-watcher-core';
 import Fastify, { type FastifyInstance } from 'fastify';
 import type pino from 'pino';
 
@@ -199,7 +202,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   });
 
   app.get(
-    '/status',
+    getEndpoint('status').path,
     withCache(cacheTtlMs, async () => {
       const result = await coreStatusHandler();
       return result.body;
@@ -207,7 +210,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/metadata',
+    getEndpoint('metadata').path,
     createMetadataHandler({
       processor,
       getConfig,
@@ -217,7 +220,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/render',
+    getEndpoint('render').path,
     withCache(
       cacheTtlMs,
       createRenderHandler({
@@ -229,7 +232,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.get(
-    '/search/facets',
+    getEndpoint('searchFacets').path,
     createFacetsHandler({
       getConfig,
       valuesManager,
@@ -238,7 +241,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/scan',
+    getEndpoint('scan').path,
     createScanHandler({
       vectorStore,
       logger,
@@ -246,7 +249,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/walk',
+    getEndpoint('walk').path,
     createWalkHandler({
       getWatchPaths: () => extractWatchPathStrings(getConfig().watch.paths),
       getFileSystemWatcher,
@@ -255,7 +258,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/search',
+    getEndpoint('search').path,
     createSearchHandler({
       embeddingProvider,
       vectorStore,
@@ -270,7 +273,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/rebuild-metadata',
+    getEndpoint('rebuildMetadata').path,
     createRebuildMetadataHandler({
       enrichmentStore: options.enrichmentStore,
       vectorStore,
@@ -279,7 +282,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/reindex',
+    getEndpoint('reindex').path,
     createConfigReindexHandler({
       getConfig,
       processor,
@@ -294,16 +297,22 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.get(
-    '/issues',
+    getEndpoint('issues').path,
     withCache(cacheTtlMs, createIssuesHandler({ issuesManager })),
   );
 
-  app.get('/config/schema', withCache(cacheTtlMs, createConfigSchemaHandler()));
+  app.get(
+    getEndpoint('configSchema').path,
+    withCache(cacheTtlMs, createConfigSchemaHandler()),
+  );
 
-  app.post('/config/match', createConfigMatchHandler({ getConfig, logger }));
+  app.post(
+    getEndpoint('configMatch').path,
+    createConfigMatchHandler({ getConfig, logger }),
+  );
 
   app.get(
-    '/config',
+    getEndpoint('config').path,
     withCache(
       cacheTtlMs,
       createConfigQueryHandler({
@@ -320,7 +329,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   );
 
   app.post(
-    '/config/validate',
+    getEndpoint('configValidate').path,
     createConfigValidateHandler({
       getConfig,
       logger,
@@ -338,7 +347,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     },
   });
 
-  app.post('/config/apply', async (request, reply) => {
+  app.post(getEndpoint('configApply').path, async (request, reply) => {
     const { patch, replace } = request.body as {
       patch: Record<string, unknown>;
       replace?: boolean;
@@ -363,7 +372,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     });
 
     app.post(
-      '/rules/register',
+      getEndpoint('rulesRegister').path,
       createRulesRegisterHandler({
         virtualRuleStore,
         logger,
@@ -372,7 +381,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     );
 
     app.delete(
-      '/rules/unregister',
+      getEndpoint('rulesUnregister').path,
       createRulesUnregisterHandler({
         virtualRuleStore,
         logger,
@@ -381,7 +390,7 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     );
 
     app.delete(
-      '/rules/unregister/:source',
+      getEndpoint('rulesUnregisterBySource').path,
       createRulesUnregisterParamHandler({
         virtualRuleStore,
         logger,
@@ -390,12 +399,12 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
     );
 
     app.post(
-      '/points/delete',
+      getEndpoint('pointsDelete').path,
       createPointsDeleteHandler({ vectorStore, logger }),
     );
 
     app.post(
-      '/rules/reapply',
+      getEndpoint('rulesReapply').path,
       createRulesReapplyHandler({ processor, vectorStore, logger }),
     );
   }
@@ -404,22 +413,40 @@ export function createApiServer(options: ApiServerOptions): FastifyInstance {
   if (options.vcsCoordinator) {
     const coordinator = options.vcsCoordinator;
 
-    app.get('/vcs/status', createVcsStatusHandler({ coordinator, logger }));
-
-    app.get('/vcs/history', createVcsHistoryHandler({ coordinator, logger }));
-
-    app.get('/vcs/show', createVcsShowHandler({ coordinator, logger }));
-
-    app.get('/vcs/diff', createVcsDiffHandler({ coordinator, logger }));
+    app.get(
+      getEndpoint('vcsStatus').path,
+      createVcsStatusHandler({ coordinator, logger }),
+    );
 
     app.get(
-      '/vcs/check-exclusion',
+      getEndpoint('vcsHistory').path,
+      createVcsHistoryHandler({ coordinator, logger }),
+    );
+
+    app.get(
+      getEndpoint('vcsShow').path,
+      createVcsShowHandler({ coordinator, logger }),
+    );
+
+    app.get(
+      getEndpoint('vcsDiff').path,
+      createVcsDiffHandler({ coordinator, logger }),
+    );
+
+    app.get(
+      getEndpoint('vcsCheckExclusion').path,
       createVcsCheckExclusionHandler({ coordinator, logger }),
     );
 
-    app.post('/vcs/revert', createVcsRevertHandler({ coordinator, logger }));
+    app.post(
+      getEndpoint('vcsRevert').path,
+      createVcsRevertHandler({ coordinator, logger }),
+    );
 
-    app.post('/vcs/exclude', createVcsExcludeHandler({ coordinator, logger }));
+    app.post(
+      getEndpoint('vcsExclude').path,
+      createVcsExcludeHandler({ coordinator, logger }),
+    );
   }
 
   return app;

--- a/packages/service/src/app/initialization.test.ts
+++ b/packages/service/src/app/initialization.test.ts
@@ -164,7 +164,7 @@ describe('initVcs', () => {
     const config = {
       vcs: {
         enabled: true,
-        commitDebounceMs: 5000,
+        commitThrottleMs: 5000,
         maxBatchSize: 1000,
       },
       watch: {
@@ -191,7 +191,7 @@ describe('initVcs', () => {
     const config = {
       vcs: {
         enabled: true,
-        commitDebounceMs: 5000,
+        commitThrottleMs: 5000,
         maxBatchSize: 1000,
       },
       watch: {
@@ -217,7 +217,7 @@ describe('initVcs', () => {
     const config = {
       vcs: {
         enabled: true,
-        commitDebounceMs: 5000,
+        commitThrottleMs: 5000,
         maxBatchSize: 1000,
         author: { name: 'root-bot', email: 'root@bot.local' },
       },
@@ -244,7 +244,7 @@ describe('initVcs', () => {
     const config = {
       vcs: {
         enabled: true,
-        commitDebounceMs: 5000,
+        commitThrottleMs: 5000,
         maxBatchSize: 1000,
         author: { name: 'root-bot', email: 'root@bot.local' },
       },

--- a/packages/service/src/vcs/VcsCoordinator.test.ts
+++ b/packages/service/src/vcs/VcsCoordinator.test.ts
@@ -64,7 +64,7 @@ describe('VcsCoordinator', () => {
     return {
       vcs: {
         enabled: true,
-        commitDebounceMs: 60000,
+        commitThrottleMs: 60000,
         maxBatchSize: 1000,
       },
       watch: {
@@ -118,7 +118,7 @@ describe('VcsCoordinator', () => {
 
   it('does not create managers when VCS is disabled', async () => {
     const config = {
-      vcs: { enabled: false, commitDebounceMs: 5000, maxBatchSize: 1000 },
+      vcs: { enabled: false, commitThrottleMs: 5000, maxBatchSize: 1000 },
       watch: { paths: [rootA], ignored: [] },
     } as unknown as JeevesWatcherConfig;
 
@@ -174,7 +174,7 @@ describe('VcsCoordinator', () => {
 
   it('creates SquashManager even when retention is omitted from config', () => {
     const config = {
-      vcs: { enabled: true, commitDebounceMs: 5000, maxBatchSize: 1000 },
+      vcs: { enabled: true, commitThrottleMs: 5000, maxBatchSize: 1000 },
       watch: { paths: [rootA], ignored: [] },
     } as unknown as JeevesWatcherConfig;
 
@@ -192,7 +192,7 @@ describe('VcsCoordinator', () => {
 
   it('uses default retention values (30 days, 100 versions, daily midnight)', () => {
     const config = {
-      vcs: { enabled: true, commitDebounceMs: 5000, maxBatchSize: 1000 },
+      vcs: { enabled: true, commitThrottleMs: 5000, maxBatchSize: 1000 },
       watch: { paths: [rootA], ignored: [] },
     } as unknown as JeevesWatcherConfig;
 
@@ -210,7 +210,7 @@ describe('VcsCoordinator', () => {
     const config = {
       vcs: {
         enabled: true,
-        commitDebounceMs: 5000,
+        commitThrottleMs: 5000,
         maxBatchSize: 1000,
         retention: {
           maxAgeDays: 7,

--- a/packages/service/src/vcs/VcsCoordinator.ts
+++ b/packages/service/src/vcs/VcsCoordinator.ts
@@ -131,8 +131,8 @@ export class VcsCoordinator {
   /**
    * Signal that the initial filesystem scan is complete.
    *
-   * Flushes each manager's debounce buffer before ending baseline mode, ensuring
-   * any files still pending in the VCS debounce are committed with a
+   * Flushes each manager's throttle buffer before ending baseline mode, ensuring
+   * any files still pending in the VCS throttle are committed with a
    * `"baseline:"` prefix rather than `"watcher:"`. AI generation is not enabled
    * until all managers have completed their flush.
    */

--- a/packages/service/src/vcs/VcsManager.test.ts
+++ b/packages/service/src/vcs/VcsManager.test.ts
@@ -24,7 +24,7 @@ const silentLogger = pino({ level: 'silent' });
 function makeConfig(overrides: Partial<VcsConfig> = {}): VcsConfig {
   return {
     enabled: true,
-    commitDebounceMs: 5000,
+    commitThrottleMs: 5000,
     maxBatchSize: 1000,
     staleLockThresholdMs: 60000,
     maxConsecutiveFailures: 5,
@@ -173,32 +173,28 @@ describe('VcsManager instance', () => {
     });
   });
 
-  describe('debounce', () => {
-    it('resets debounce timer on each fileChanged call', async () => {
+  describe('throttle', () => {
+    it('does not reset throttle timer on subsequent fileChanged calls', async () => {
       vi.useFakeTimers();
 
-      const config = makeConfig({ commitDebounceMs: 5000 });
+      const config = makeConfig({ commitThrottleMs: 5000 });
       const manager = new VcsManager(tempDir, config, silentLogger);
       manager.start();
 
       // Mock flush to avoid real git operations with fake timers
       const flushSpy = vi.spyOn(manager, 'flush').mockResolvedValue(undefined);
 
-      const filePath = join(tempDir, 'debounce.txt');
+      const filePath = join(tempDir, 'throttle.txt');
       manager.fileChanged(filePath);
 
       // Advance 3 seconds — flush should not fire yet
       await vi.advanceTimersByTimeAsync(3000);
       expect(flushSpy).not.toHaveBeenCalled();
 
-      // File changed again — resets the timer
+      // File changed again — does NOT reset the timer (throttle, not debounce)
       manager.fileChanged(filePath);
 
-      // Advance 3 more seconds (6 total, but only 3 since last change)
-      await vi.advanceTimersByTimeAsync(3000);
-      expect(flushSpy).not.toHaveBeenCalled();
-
-      // Advance 2 more seconds (5 total since last change) — flush fires
+      // Advance 2 more seconds (5 total since first change) — flush fires
       await vi.advanceTimersByTimeAsync(2000);
       expect(flushSpy).toHaveBeenCalledTimes(1);
 
@@ -210,7 +206,7 @@ describe('VcsManager instance', () => {
     it('flushes immediately when pending exceeds maxBatchSize', async () => {
       const config = makeConfig({
         maxBatchSize: 3,
-        commitDebounceMs: 60000,
+        commitThrottleMs: 60000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
       manager.start();
@@ -236,7 +232,7 @@ describe('VcsManager instance', () => {
     it('starts new timer for overflow when batch exceeds maxBatchSize', async () => {
       const config = makeConfig({
         maxBatchSize: 2,
-        commitDebounceMs: 1000,
+        commitThrottleMs: 1000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
       manager.start();
@@ -248,7 +244,7 @@ describe('VcsManager instance', () => {
         manager.fileChanged(filePath);
       }
 
-      // Wait for in-flight batch to complete, then wait for debounce on overflow
+      // Wait for in-flight batch to complete, then wait for throttle on overflow
       await manager.flush();
 
       // Should have 2 commits: one from maxBatchSize (2 files), one from flush (1 file)
@@ -585,7 +581,7 @@ describe('VcsManager instance', () => {
       // maxBatchSize=3: each failed batch re-queues at most 3 files
       const config = makeConfig({
         maxBatchSize: 3,
-        commitDebounceMs: 60000,
+        commitThrottleMs: 60000,
         maxConsecutiveFailures: 100,
       });
       const manager = new VcsManager(tempDir, config, logger);

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -24,7 +24,7 @@ export type { PendingReversion, PushError };
  * Per-root VCS manager for git-backed content versioning.
  *
  * Each VCS-enabled watch root gets its own VcsManager instance, which owns
- * a debounced commit pipeline: file changes are batched, staged, committed
+ * a throttled commit pipeline: file changes are batched, staged, committed
  * (with optional AI-generated messages), and optionally pushed to a remote.
  *
  * Concurrency: only one commit is in-flight at a time per root. Index.lock
@@ -41,7 +41,7 @@ export class VcsManager {
   private readonly pendingReversions: PendingReversion[] = [];
   private readonly _pushErrors: PushError[] = [];
   private readonly squashManager: SquashManager | undefined;
-  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private throttleTimer: ReturnType<typeof setTimeout> | undefined;
   private commitInFlight: Promise<void> = Promise.resolve();
   private consecutiveCommitFailures = 0;
   private started = false;
@@ -109,7 +109,7 @@ export class VcsManager {
   }
 
   /**
-   * Add a file to the pending set and reset the debounce timer.
+   * Add a file to the pending set and start the throttle timer.
    * If the pending set exceeds maxBatchSize, flush immediately.
    *
    * @param filePath - Absolute path of the changed file.
@@ -129,18 +129,18 @@ export class VcsManager {
     this.pending.add(filePath);
 
     if (this.pending.size >= this.config.maxBatchSize) {
-      this.clearDebounce();
+      this.clearThrottle();
       const batch = this.takeBatch(this.config.maxBatchSize);
       this.commitInFlight = this.commitInFlight.then(() =>
         this.commitBatch(batch),
       );
       if (this.pending.size > 0) {
-        this.resetDebounce();
+        this.resetThrottle();
       }
       return;
     }
 
-    this.resetDebounce();
+    this.resetThrottle();
   }
 
   /**
@@ -167,7 +167,7 @@ export class VcsManager {
    * Flush all pending files immediately.
    */
   async flush(): Promise<void> {
-    this.clearDebounce();
+    this.clearThrottle();
     if (this.pending.size > 0) {
       const batch = [...this.pending];
       this.pending.clear();
@@ -204,24 +204,25 @@ export class VcsManager {
   }
 
   /**
-   * Clear the debounce timer.
+   * Clear the throttle timer.
    */
-  private clearDebounce(): void {
-    if (this.debounceTimer !== undefined) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = undefined;
+  private clearThrottle(): void {
+    if (this.throttleTimer !== undefined) {
+      clearTimeout(this.throttleTimer);
+      this.throttleTimer = undefined;
     }
   }
 
   /**
-   * Reset the debounce timer to fire flush() after commitDebounceMs.
+   * Start the throttle timer to fire flush() after commitThrottleMs.
+   * If a timer is already running, do not reset it — this is throttle, not debounce.
    */
-  private resetDebounce(): void {
-    this.clearDebounce();
-    this.debounceTimer = setTimeout(() => {
-      this.debounceTimer = undefined;
+  private resetThrottle(): void {
+    if (this.throttleTimer !== undefined) return;
+    this.throttleTimer = setTimeout(() => {
+      this.throttleTimer = undefined;
       void this.flush();
-    }, this.config.commitDebounceMs);
+    }, this.config.commitThrottleMs);
   }
 
   /**

--- a/packages/service/src/vcs/resolveWatchRoot.test.ts
+++ b/packages/service/src/vcs/resolveWatchRoot.test.ts
@@ -33,7 +33,7 @@ describe('resolveWatchRoot', () => {
 
   function makeCoordinator(roots: string[]): VcsCoordinator {
     const config = {
-      vcs: { enabled: true, commitDebounceMs: 5000, maxBatchSize: 1000 },
+      vcs: { enabled: true, commitThrottleMs: 5000, maxBatchSize: 1000 },
       watch: { paths: roots, ignored: [] },
     } as unknown as JeevesWatcherConfig;
     return new VcsCoordinator(config, silentLogger);
@@ -91,7 +91,7 @@ describe('resolveWatchRootsForGlob', () => {
 
   function makeCoordinator(roots: string[]): VcsCoordinator {
     const config = {
-      vcs: { enabled: true, commitDebounceMs: 5000, maxBatchSize: 1000 },
+      vcs: { enabled: true, commitThrottleMs: 5000, maxBatchSize: 1000 },
       watch: { paths: roots, ignored: [] },
     } as unknown as JeevesWatcherConfig;
     return new VcsCoordinator(config, silentLogger);


### PR DESCRIPTION
Cherry-picked from main to restore proper PR workflow. Two changes:

- **#221** — Replace VCS commit debounce with throttle. resetThrottle() now returns early if a timer exists instead of clearing/resetting. Guarantees commits fire at the configured interval regardless of continuous file activity. Renamed commitDebounceMs to commitThrottleMs across schema, service, tests, and docs.

- **#196** — Shared endpoint catalog in core package following the jeeves-meta pattern. WATCHER_ENDPOINTS array with 27 endpoint descriptors, EndpointName type, getEndpoint() lookup.

Closes #221, #196