### PR TITLE
fix: append /** to bare directory watch paths (fixes #224)

### DIFF
--- a/packages/service/src/watcher/globToDir.test.ts
+++ b/packages/service/src/watcher/globToDir.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildGlobMatcher,
   deduplicateRoots,
+  expandBareDirectoryGlob,
   globRoot,
   resolveIgnored,
   resolveWatchPaths,
@@ -93,6 +94,46 @@ describe('buildGlobMatcher', () => {
   });
 });
 
+describe('expandBareDirectoryGlob', () => {
+  it('appends /** to a bare directory path', () => {
+    expect(expandBareDirectoryGlob('j:/domains')).toBe('j:/domains/**');
+  });
+
+  it('appends /** to a deep bare directory path', () => {
+    expect(expandBareDirectoryGlob('/opt/jeeves/content')).toBe(
+      '/opt/jeeves/content/**',
+    );
+  });
+
+  it('strips trailing slash before appending /**', () => {
+    expect(expandBareDirectoryGlob('j:/domains/')).toBe('j:/domains/**');
+  });
+
+  it('does not modify a path that already has glob characters', () => {
+    expect(expandBareDirectoryGlob('j:/domains/**/*.json')).toBe(
+      'j:/domains/**/*.json',
+    );
+  });
+
+  it('does not modify a path with a question-mark glob', () => {
+    expect(expandBareDirectoryGlob('j:/domains/file?.json')).toBe(
+      'j:/domains/file?.json',
+    );
+  });
+
+  it('does not modify a path with a brace glob', () => {
+    expect(expandBareDirectoryGlob('j:/domains/**/*.{json,md}')).toBe(
+      'j:/domains/**/*.{json,md}',
+    );
+  });
+
+  it('does not modify a path with a bracket glob', () => {
+    expect(expandBareDirectoryGlob('j:/domains/[abc].json')).toBe(
+      'j:/domains/[abc].json',
+    );
+  });
+});
+
 describe('resolveWatchPaths', () => {
   it('returns deduplicated roots and a working matcher', () => {
     const { roots, matches } = resolveWatchPaths([
@@ -105,6 +146,41 @@ describe('resolveWatchPaths', () => {
     expect(matches('j:/domains/jira/WEB-1.json')).toBe(true);
     expect(matches('j:/config/watcher.json')).toBe(true);
     expect(matches('j:/domains/file.py')).toBe(false);
+  });
+
+  it('bare directory path matches files recursively under it', () => {
+    const { matches } = resolveWatchPaths(['/opt/jeeves/content']);
+
+    expect(matches('/opt/jeeves/content/legacy/slack/file.json')).toBe(true);
+    expect(matches('/opt/jeeves/content/readme.md')).toBe(true);
+    expect(matches('/opt/jeeves/other/file.json')).toBe(false);
+  });
+
+  it('bare directory path produces the correct chokidar root', () => {
+    const { roots } = resolveWatchPaths(['/opt/jeeves/content']);
+    expect(roots).toEqual(['/opt/jeeves/content']);
+  });
+
+  it('mix of bare paths and glob patterns works correctly', () => {
+    const { roots, matches } = resolveWatchPaths([
+      'j:/domains',
+      'j:/config/**/*.json',
+    ]);
+
+    expect(roots).toEqual(['j:/config', 'j:/domains']);
+    expect(matches('j:/domains/legacy/slack/file.md')).toBe(true);
+    expect(matches('j:/config/watcher.json')).toBe(true);
+    expect(matches('j:/config/readme.md')).toBe(false);
+    expect(matches('/opt/other/file.json')).toBe(false);
+  });
+
+  it('paths with glob characters are not modified (regression guard)', () => {
+    const { matches } = resolveWatchPaths(['j:/domains/**/*.json']);
+
+    // Files matching the original glob still match
+    expect(matches('j:/domains/jira/WEB-1.json')).toBe(true);
+    // Files that would only match if /** were appended (non-json) should not
+    expect(matches('j:/domains/jira/WEB-1.md')).toBe(false);
   });
 });
 

--- a/packages/service/src/watcher/globToDir.ts
+++ b/packages/service/src/watcher/globToDir.ts
@@ -70,8 +70,26 @@ export function buildGlobMatcher(
 }
 
 /**
+ * Expand a bare directory path (no glob characters) to a recursive glob.
+ * A path like `/opt/jeeves/content` becomes `/opt/jeeves/content/**`.
+ * Paths that already contain glob characters are returned unchanged.
+ *
+ * @param glob - A glob pattern or bare directory path.
+ * @returns The original glob, or the path suffixed with `/**` if bare.
+ */
+export function expandBareDirectoryGlob(glob: string): string {
+  const normalized = normalizeSlashes(glob);
+  if (/[*?{[\]]/.test(normalized)) return glob;
+  return glob.replace(/\/+$/, '') + '/**';
+}
+
+/**
  * Convert an array of glob patterns into chokidar-compatible directory roots
  * and a filter function for post-hoc event filtering.
+ *
+ * Bare directory paths (no glob characters, e.g. `/opt/jeeves/content`) are
+ * automatically expanded to recursive globs (`/opt/jeeves/content/**`) so that
+ * picomatch matches all files underneath them.
  *
  * @param globs - Glob patterns from the watch config.
  * @returns Object with `roots` (directories for chokidar) and `matches` (filter function).
@@ -80,9 +98,10 @@ export function resolveWatchPaths(globs: string[]): {
   roots: string[];
   matches: (filePath: string) => boolean;
 } {
-  const rawRoots = globs.map(globRoot);
+  const expandedGlobs = globs.map(expandBareDirectoryGlob);
+  const rawRoots = expandedGlobs.map(globRoot);
   const roots = deduplicateRoots(rawRoots);
-  const matches = buildGlobMatcher(globs);
+  const matches = buildGlobMatcher(expandedGlobs);
   return { roots, matches };
 }
 


### PR DESCRIPTION
Resolves #224. Bare directory watch paths (no glob characters) are now automatically suffixed with \/**\ in \esolveWatchPaths\, making them match all files recursively. Previously, picomatch treated them as literal strings and rejected every file event.