### PR TITLE
[230] fix: squashmanager compound defect

### DIFF
--- a/packages/core/src/schemas/vcs.ts
+++ b/packages/core/src/schemas/vcs.ts
@@ -159,6 +159,12 @@ export const vcsConfigSchema = z.object({
     .describe(
       'Circuit breaker: stop re-queuing after this many consecutive commit failures. Default: 5.',
     ),
+  /** Git branch name for VCS operations. SquashManager and startup recovery use this instead of dynamic detection. */
+  branch: z
+    .string()
+    .min(1)
+    .default('master')
+    .describe('Git branch name for VCS operations. Default: "master".'),
 });
 
 /** Root-level VCS configuration. */

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -31,6 +31,7 @@ Add a `vcs` block to your config:
     "enabled": true,
     "commitThrottleMs": 30000,
     "maxBatchSize": 1000,
+    "branch": "master",
     "commitMessage": {
       "enabled": true,
       "provider": "anthropic",
@@ -52,6 +53,7 @@ Add a `vcs` block to your config:
 | `vcs.enabled` | `false` | Enable git-backed version control globally |
 | `vcs.commitThrottleMs` | `30000` | Throttle interval (ms) for batching file changes into commits. Min: 1000 |
 | `vcs.maxBatchSize` | `1000` | Maximum files per commit batch. Flushes immediately when exceeded. Min: 1 |
+| `vcs.branch` | `"master"` | Git branch name for VCS operations. Squash retention and startup recovery target this branch |
 | `vcs.commitMessage.enabled` | `true` | Enable AI-generated commit messages |
 | `vcs.commitMessage.provider` | `"anthropic"` | AI provider (currently only `"anthropic"` supported) |
 | `vcs.commitMessage.model` | `"claude-haiku-4-0"` | AI model for commit message generation |

--- a/packages/service/config.schema.json
+++ b/packages/service/config.schema.json
@@ -25,25 +25,25 @@
           "$ref": "#/definitions/__schema5"
         },
         "ignored": {
-          "$ref": "#/definitions/__schema37"
-        },
-        "pollIntervalMs": {
           "$ref": "#/definitions/__schema39"
         },
-        "usePolling": {
+        "pollIntervalMs": {
           "$ref": "#/definitions/__schema41"
         },
-        "debounceMs": {
+        "usePolling": {
           "$ref": "#/definitions/__schema43"
         },
-        "stabilityThresholdMs": {
+        "debounceMs": {
           "$ref": "#/definitions/__schema45"
         },
-        "respectGitignore": {
+        "stabilityThresholdMs": {
           "$ref": "#/definitions/__schema47"
         },
-        "moveDetection": {
+        "respectGitignore": {
           "$ref": "#/definitions/__schema49"
+        },
+        "moveDetection": {
+          "$ref": "#/definitions/__schema51"
         }
       },
       "required": [
@@ -55,7 +55,7 @@
       "description": "Configuration file watch settings.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema53"
+          "$ref": "#/definitions/__schema55"
         }
       ]
     },
@@ -63,28 +63,28 @@
       "type": "object",
       "properties": {
         "provider": {
-          "$ref": "#/definitions/__schema57"
-        },
-        "model": {
           "$ref": "#/definitions/__schema59"
         },
-        "chunkSize": {
+        "model": {
           "$ref": "#/definitions/__schema61"
         },
-        "chunkOverlap": {
+        "chunkSize": {
           "$ref": "#/definitions/__schema63"
         },
-        "dimensions": {
+        "chunkOverlap": {
           "$ref": "#/definitions/__schema65"
         },
-        "apiKey": {
+        "dimensions": {
           "$ref": "#/definitions/__schema67"
         },
-        "rateLimitPerMinute": {
+        "apiKey": {
           "$ref": "#/definitions/__schema69"
         },
-        "concurrency": {
+        "rateLimitPerMinute": {
           "$ref": "#/definitions/__schema71"
+        },
+        "concurrency": {
+          "$ref": "#/definitions/__schema73"
         }
       },
       "description": "Embedding model configuration."
@@ -93,13 +93,13 @@
       "type": "object",
       "properties": {
         "url": {
-          "$ref": "#/definitions/__schema73"
+          "$ref": "#/definitions/__schema75"
         },
         "collectionName": {
-          "$ref": "#/definitions/__schema74"
+          "$ref": "#/definitions/__schema76"
         },
         "apiKey": {
-          "$ref": "#/definitions/__schema75"
+          "$ref": "#/definitions/__schema77"
         }
       },
       "required": [
@@ -112,7 +112,7 @@
       "description": "API server configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema77"
+          "$ref": "#/definitions/__schema79"
         }
       ]
     },
@@ -120,7 +120,7 @@
       "description": "Directory for persistent state files (issues.json, values.json, enrichments.sqlite). Defaults to .jeeves-metadata.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema81"
+          "$ref": "#/definitions/__schema83"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "description": "Rules for inferring metadata from file attributes. Each entry may be an inline rule object or a file path to a JSON rule file (resolved relative to config directory).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema82"
+          "$ref": "#/definitions/__schema84"
         }
       ]
     },
@@ -136,7 +136,7 @@
       "description": "Reusable named JsonMap transformations (inline definition or .json file path resolved relative to config directory).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema109"
+          "$ref": "#/definitions/__schema111"
         }
       ]
     },
@@ -144,7 +144,7 @@
       "description": "Named reusable Handlebars templates (inline strings or .hbs/.handlebars file paths).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema110"
+          "$ref": "#/definitions/__schema112"
         }
       ]
     },
@@ -152,7 +152,7 @@
       "description": "Custom Handlebars helper registration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema111"
+          "$ref": "#/definitions/__schema113"
         }
       ]
     },
@@ -160,7 +160,7 @@
       "description": "Custom JsonMap lib function registration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema112"
+          "$ref": "#/definitions/__schema114"
         }
       ]
     },
@@ -168,7 +168,7 @@
       "description": "Reindex configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema113"
+          "$ref": "#/definitions/__schema115"
         }
       ]
     },
@@ -176,7 +176,7 @@
       "description": "Search configuration including score thresholds and hybrid search.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema115"
+          "$ref": "#/definitions/__schema117"
         }
       ]
     },
@@ -184,7 +184,7 @@
       "description": "VCS configuration for git-backed version control of watched content.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema116"
+          "$ref": "#/definitions/__schema118"
         }
       ]
     },
@@ -192,7 +192,7 @@
       "description": "Logging configuration.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema117"
+          "$ref": "#/definitions/__schema119"
         }
       ]
     },
@@ -200,7 +200,7 @@
       "description": "Timeout in milliseconds for graceful shutdown.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema120"
+          "$ref": "#/definitions/__schema122"
         }
       ]
     },
@@ -208,7 +208,7 @@
       "description": "Maximum consecutive system-level failures before triggering fatal error. Default: Infinity.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema121"
+          "$ref": "#/definitions/__schema123"
         }
       ]
     },
@@ -216,7 +216,7 @@
       "description": "Maximum backoff delay in milliseconds for system errors. Default: 60000.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema122"
+          "$ref": "#/definitions/__schema124"
         }
       ]
     }
@@ -387,11 +387,18 @@
             }
           ]
         },
+        "branch": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema35"
+            }
+          ]
+        },
         "remote": {
           "description": "Git remote URL for this watch root.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema35"
+              "$ref": "#/definitions/__schema37"
             }
           ]
         },
@@ -399,7 +406,7 @@
           "description": "Access token override for this watch root. Supports env var substitution (e.g., \"${GIT_TOKEN}\").",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema36"
+              "$ref": "#/definitions/__schema38"
             }
           ]
         }
@@ -637,30 +644,29 @@
       "maximum": 9007199254740991
     },
     "__schema35": {
-      "type": "string"
+      "default": "master",
+      "description": "Git branch name for VCS operations. Default: \"master\".",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema36"
+        }
+      ]
     },
     "__schema36": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "__schema37": {
+      "type": "string"
+    },
+    "__schema38": {
+      "type": "string"
+    },
+    "__schema39": {
       "default": [
         "**/node_modules/**"
       ],
       "description": "Glob patterns to exclude from watching (e.g., \"**/node_modules/**\").",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema38"
-        }
-      ]
-    },
-    "__schema38": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "__schema39": {
-      "description": "Polling interval in milliseconds when usePolling is enabled.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema40"
@@ -668,10 +674,13 @@
       ]
     },
     "__schema40": {
-      "type": "number"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "__schema41": {
-      "description": "Use polling instead of native file system events (for network drives).",
+      "description": "Polling interval in milliseconds when usePolling is enabled.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema42"
@@ -679,10 +688,10 @@
       ]
     },
     "__schema42": {
-      "type": "boolean"
+      "type": "number"
     },
     "__schema43": {
-      "description": "Debounce delay in milliseconds for file change events.",
+      "description": "Use polling instead of native file system events (for network drives).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema44"
@@ -690,10 +699,10 @@
       ]
     },
     "__schema44": {
-      "type": "number"
+      "type": "boolean"
     },
     "__schema45": {
-      "description": "Time in milliseconds a file must remain unchanged before processing.",
+      "description": "Debounce delay in milliseconds for file change events.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema46"
@@ -704,7 +713,7 @@
       "type": "number"
     },
     "__schema47": {
-      "description": "Skip files ignored by .gitignore in git repositories. Only applies to repos with a .git directory. Default: true.",
+      "description": "Time in milliseconds a file must remain unchanged before processing.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema48"
@@ -712,10 +721,10 @@
       ]
     },
     "__schema48": {
-      "type": "boolean"
+      "type": "number"
     },
     "__schema49": {
-      "description": "Move detection: correlate unlink+add events as file moves to avoid re-embedding.",
+      "description": "Skip files ignored by .gitignore in git repositories. Only applies to repos with a .git directory. Default: true.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema50"
@@ -723,6 +732,17 @@
       ]
     },
     "__schema50": {
+      "type": "boolean"
+    },
+    "__schema51": {
+      "description": "Move detection: correlate unlink+add events as file moves to avoid re-embedding.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema52"
+        }
+      ]
+    },
+    "__schema52": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -730,7 +750,7 @@
           "description": "Enable move detection via content hash correlation.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema51"
+              "$ref": "#/definitions/__schema53"
             }
           ]
         },
@@ -739,28 +759,28 @@
           "description": "How long (ms) to buffer unlink events before treating as deletes.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema52"
+              "$ref": "#/definitions/__schema54"
             }
           ]
         }
       }
     },
-    "__schema51": {
+    "__schema53": {
       "type": "boolean"
     },
-    "__schema52": {
+    "__schema54": {
       "type": "integer",
       "minimum": 100,
       "maximum": 9007199254740991
     },
-    "__schema53": {
+    "__schema55": {
       "type": "object",
       "properties": {
         "enabled": {
           "description": "Enable automatic reloading when config file changes.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema54"
+              "$ref": "#/definitions/__schema56"
             }
           ]
         },
@@ -768,7 +788,7 @@
           "description": "Debounce delay in milliseconds for config file change detection.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema55"
+              "$ref": "#/definitions/__schema57"
             }
           ]
         },
@@ -776,19 +796,19 @@
           "description": "Reindex scope triggered on config change. Default: issues.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema56"
+              "$ref": "#/definitions/__schema58"
             }
           ]
         }
       }
     },
-    "__schema54": {
+    "__schema56": {
       "type": "boolean"
     },
-    "__schema55": {
+    "__schema57": {
       "type": "number"
     },
-    "__schema56": {
+    "__schema58": {
       "anyOf": [
         {
           "type": "string",
@@ -807,21 +827,9 @@
         }
       ]
     },
-    "__schema57": {
+    "__schema59": {
       "default": "gemini",
       "description": "Embedding provider name (e.g., \"gemini\", \"openai\").",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema58"
-        }
-      ]
-    },
-    "__schema58": {
-      "type": "string"
-    },
-    "__schema59": {
-      "default": "gemini-embedding-001",
-      "description": "Embedding model identifier (e.g., \"gemini-embedding-001\", \"text-embedding-3-small\").",
       "allOf": [
         {
           "$ref": "#/definitions/__schema60"
@@ -832,7 +840,8 @@
       "type": "string"
     },
     "__schema61": {
-      "description": "Maximum chunk size in characters for text splitting.",
+      "default": "gemini-embedding-001",
+      "description": "Embedding model identifier (e.g., \"gemini-embedding-001\", \"text-embedding-3-small\").",
       "allOf": [
         {
           "$ref": "#/definitions/__schema62"
@@ -840,10 +849,10 @@
       ]
     },
     "__schema62": {
-      "type": "number"
+      "type": "string"
     },
     "__schema63": {
-      "description": "Character overlap between consecutive chunks.",
+      "description": "Maximum chunk size in characters for text splitting.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema64"
@@ -854,7 +863,7 @@
       "type": "number"
     },
     "__schema65": {
-      "description": "Embedding vector dimensions (must match model output).",
+      "description": "Character overlap between consecutive chunks.",
       "allOf": [
         {
           "$ref": "#/definitions/__schema66"
@@ -865,7 +874,7 @@
       "type": "number"
     },
     "__schema67": {
-      "description": "API key for embedding provider (supports ${ENV_VAR} substitution).",
+      "description": "Embedding vector dimensions (must match model output).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema68"
@@ -873,10 +882,10 @@
       ]
     },
     "__schema68": {
-      "type": "string"
+      "type": "number"
     },
     "__schema69": {
-      "description": "Maximum embedding API requests per minute (rate limiting).",
+      "description": "API key for embedding provider (supports ${ENV_VAR} substitution).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema70"
@@ -884,10 +893,10 @@
       ]
     },
     "__schema70": {
-      "type": "number"
+      "type": "string"
     },
     "__schema71": {
-      "description": "Maximum concurrent embedding requests.",
+      "description": "Maximum embedding API requests per minute (rate limiting).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema72"
@@ -898,32 +907,43 @@
       "type": "number"
     },
     "__schema73": {
-      "type": "string",
-      "description": "Qdrant server URL (e.g., \"http://localhost:6333\")."
-    },
-    "__schema74": {
-      "type": "string",
-      "description": "Qdrant collection name for vector storage."
-    },
-    "__schema75": {
-      "description": "Qdrant API key for authentication (supports ${ENV_VAR} substitution).",
+      "description": "Maximum concurrent embedding requests.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema76"
+          "$ref": "#/definitions/__schema74"
         }
       ]
     },
+    "__schema74": {
+      "type": "number"
+    },
+    "__schema75": {
+      "type": "string",
+      "description": "Qdrant server URL (e.g., \"http://localhost:6333\")."
+    },
     "__schema76": {
-      "type": "string"
+      "type": "string",
+      "description": "Qdrant collection name for vector storage."
     },
     "__schema77": {
+      "description": "Qdrant API key for authentication (supports ${ENV_VAR} substitution).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema78"
+        }
+      ]
+    },
+    "__schema78": {
+      "type": "string"
+    },
+    "__schema79": {
       "type": "object",
       "properties": {
         "host": {
           "description": "Host address for API server (e.g., \"127.0.0.1\", \"0.0.0.0\").",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema78"
+              "$ref": "#/definitions/__schema80"
             }
           ]
         },
@@ -931,7 +951,7 @@
           "description": "Port for API server (e.g., 1936).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema79"
+              "$ref": "#/definitions/__schema81"
             }
           ]
         },
@@ -939,25 +959,25 @@
           "description": "TTL in milliseconds for caching read-heavy endpoints (e.g., /status, /config). Default: 30000.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema80"
+              "$ref": "#/definitions/__schema82"
             }
           ]
         }
       }
     },
-    "__schema78": {
-      "type": "string"
-    },
-    "__schema79": {
-      "type": "number"
-    },
     "__schema80": {
-      "type": "number"
+      "type": "string"
     },
     "__schema81": {
-      "type": "string"
+      "type": "number"
     },
     "__schema82": {
+      "type": "number"
+    },
+    "__schema83": {
+      "type": "string"
+    },
+    "__schema84": {
       "type": "array",
       "items": {
         "anyOf": [
@@ -965,28 +985,28 @@
             "type": "object",
             "properties": {
               "name": {
-                "$ref": "#/definitions/__schema83"
-              },
-              "description": {
-                "$ref": "#/definitions/__schema84"
-              },
-              "match": {
                 "$ref": "#/definitions/__schema85"
               },
-              "schema": {
-                "$ref": "#/definitions/__schema88"
+              "description": {
+                "$ref": "#/definitions/__schema86"
               },
-              "map": {
+              "match": {
+                "$ref": "#/definitions/__schema87"
+              },
+              "schema": {
                 "$ref": "#/definitions/__schema90"
               },
-              "template": {
-                "$ref": "#/definitions/__schema94"
+              "map": {
+                "$ref": "#/definitions/__schema92"
               },
-              "render": {
+              "template": {
                 "$ref": "#/definitions/__schema96"
               },
+              "render": {
+                "$ref": "#/definitions/__schema98"
+              },
               "renderAs": {
-                "$ref": "#/definitions/__schema107"
+                "$ref": "#/definitions/__schema109"
               }
             },
             "required": [
@@ -1001,39 +1021,39 @@
         ]
       }
     },
-    "__schema83": {
+    "__schema85": {
       "type": "string",
       "minLength": 1,
       "description": "Unique name identifying this inference rule."
     },
-    "__schema84": {
+    "__schema86": {
       "type": "string",
       "minLength": 1,
       "description": "Human-readable description of what this rule does."
     },
-    "__schema85": {
+    "__schema87": {
       "type": "object",
       "propertyNames": {
-        "$ref": "#/definitions/__schema86"
+        "$ref": "#/definitions/__schema88"
       },
       "additionalProperties": {
-        "$ref": "#/definitions/__schema87"
+        "$ref": "#/definitions/__schema89"
       },
       "description": "JSON Schema object to match against file attributes."
     },
-    "__schema86": {
+    "__schema88": {
       "type": "string"
     },
-    "__schema87": {},
-    "__schema88": {
+    "__schema89": {},
+    "__schema90": {
       "description": "Array of schema references (named schema refs or inline objects) merged left-to-right.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema89"
+          "$ref": "#/definitions/__schema91"
         }
       ]
     },
-    "__schema89": {
+    "__schema91": {
       "type": "array",
       "items": {
         "anyOf": [
@@ -1047,25 +1067,25 @@
         ]
       }
     },
-    "__schema90": {
+    "__schema92": {
       "description": "JsonMap transformation (inline definition, named map reference, or .json file path).",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema91"
+          "$ref": "#/definitions/__schema93"
         }
       ]
     },
-    "__schema91": {
+    "__schema93": {
       "anyOf": [
         {
-          "$ref": "#/definitions/__schema92"
+          "$ref": "#/definitions/__schema94"
         },
         {
           "type": "string"
         }
       ]
     },
-    "__schema92": {
+    "__schema94": {
       "anyOf": [
         {
           "anyOf": [
@@ -1091,7 +1111,7 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "$ref": "#/definitions/__schema92"
+                "$ref": "#/definitions/__schema94"
               },
               {
                 "type": "object",
@@ -1099,12 +1119,12 @@
                   "$": {
                     "anyOf": [
                       {
-                        "$ref": "#/definitions/__schema93"
+                        "$ref": "#/definitions/__schema95"
                       },
                       {
                         "type": "array",
                         "items": {
-                          "$ref": "#/definitions/__schema93"
+                          "$ref": "#/definitions/__schema95"
                         }
                       }
                     ]
@@ -1120,12 +1140,12 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/__schema92"
+            "$ref": "#/definitions/__schema94"
           }
         }
       ]
     },
-    "__schema93": {
+    "__schema95": {
       "type": "object",
       "properties": {
         "method": {
@@ -1150,19 +1170,8 @@
         "params"
       ]
     },
-    "__schema94": {
-      "description": "Handlebars content template (inline string, named ref, or .hbs/.handlebars file path).",
-      "allOf": [
-        {
-          "$ref": "#/definitions/__schema95"
-        }
-      ]
-    },
-    "__schema95": {
-      "type": "string"
-    },
     "__schema96": {
-      "description": "Declarative render configuration for frontmatter + structured Markdown output (mutually exclusive with template).",
+      "description": "Handlebars content template (inline string, named ref, or .hbs/.handlebars file path).",
       "allOf": [
         {
           "$ref": "#/definitions/__schema97"
@@ -1170,19 +1179,30 @@
       ]
     },
     "__schema97": {
+      "type": "string"
+    },
+    "__schema98": {
+      "description": "Declarative render configuration for frontmatter + structured Markdown output (mutually exclusive with template).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema99"
+        }
+      ]
+    },
+    "__schema99": {
       "type": "object",
       "properties": {
         "frontmatter": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/__schema98"
+            "$ref": "#/definitions/__schema100"
           },
           "description": "Keys or glob patterns to include as YAML frontmatter. Supports picomatch globs (e.g. \"*\") and \"!\"-prefixed exclusion patterns (e.g. \"!_*\"). Explicit names preserve declaration order; glob-matched keys are sorted alphabetically."
         },
         "body": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/__schema99"
+            "$ref": "#/definitions/__schema101"
           },
           "description": "Ordered markdown body sections."
         }
@@ -1192,11 +1212,11 @@
         "body"
       ]
     },
-    "__schema98": {
+    "__schema100": {
       "type": "string",
       "minLength": 1
     },
-    "__schema99": {
+    "__schema101": {
       "type": "object",
       "properties": {
         "path": {
@@ -1214,7 +1234,7 @@
           "description": "Override heading text.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema100"
+              "$ref": "#/definitions/__schema102"
             }
           ]
         },
@@ -1222,7 +1242,7 @@
           "description": "Name of a registered Handlebars helper used as a format handler.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema101"
+              "$ref": "#/definitions/__schema103"
             }
           ]
         },
@@ -1230,7 +1250,7 @@
           "description": "Additional args passed to the format helper.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema102"
+              "$ref": "#/definitions/__schema104"
             }
           ]
         },
@@ -1238,7 +1258,7 @@
           "description": "If true, the value at path is treated as an array and iterated.",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema103"
+              "$ref": "#/definitions/__schema105"
             }
           ]
         },
@@ -1246,7 +1266,7 @@
           "description": "Handlebars template string for per-item heading text (used when each=true).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema104"
+              "$ref": "#/definitions/__schema106"
             }
           ]
         },
@@ -1254,7 +1274,7 @@
           "description": "Key path within each item to use as renderable content (used when each=true).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema105"
+              "$ref": "#/definitions/__schema107"
             }
           ]
         },
@@ -1262,7 +1282,7 @@
           "description": "Key path within each item to sort by (used when each=true).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema106"
+              "$ref": "#/definitions/__schema108"
             }
           ]
         }
@@ -1272,41 +1292,41 @@
         "heading"
       ]
     },
-    "__schema100": {
-      "type": "string"
-    },
-    "__schema101": {
-      "type": "string"
-    },
     "__schema102": {
+      "type": "string"
+    },
+    "__schema103": {
+      "type": "string"
+    },
+    "__schema104": {
       "type": "array",
       "items": {}
     },
-    "__schema103": {
-      "type": "boolean"
-    },
-    "__schema104": {
-      "type": "string"
-    },
     "__schema105": {
-      "type": "string"
+      "type": "boolean"
     },
     "__schema106": {
       "type": "string"
     },
     "__schema107": {
+      "type": "string"
+    },
+    "__schema108": {
+      "type": "string"
+    },
+    "__schema109": {
       "description": "Output file extension override (without dot). Requires template or render.",
       "allOf": [
         {
-          "$ref": "#/definitions/__schema108"
+          "$ref": "#/definitions/__schema110"
         }
       ]
     },
-    "__schema108": {
+    "__schema110": {
       "type": "string",
       "pattern": "^[a-z0-9]{1,10}$"
     },
-    "__schema109": {
+    "__schema111": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1314,7 +1334,7 @@
       "additionalProperties": {
         "anyOf": [
           {
-            "$ref": "#/definitions/__schema92"
+            "$ref": "#/definitions/__schema94"
           },
           {
             "type": "string"
@@ -1325,7 +1345,7 @@
               "map": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/__schema92"
+                    "$ref": "#/definitions/__schema94"
                   },
                   {
                     "type": "string"
@@ -1343,7 +1363,7 @@
         ]
       }
     },
-    "__schema110": {
+    "__schema112": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1370,47 +1390,47 @@
         ]
       }
     },
-    "__schema111": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      }
-    },
-    "__schema112": {
-      "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      }
-    },
     "__schema113": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      }
+    },
+    "__schema114": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      }
+    },
+    "__schema115": {
       "type": "object",
       "properties": {
         "callbackUrl": {
@@ -1422,18 +1442,18 @@
           "description": "Maximum concurrent file operations during reindex (default 50).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema114"
+              "$ref": "#/definitions/__schema116"
             }
           ]
         }
       }
     },
-    "__schema114": {
+    "__schema116": {
       "type": "integer",
       "minimum": 1,
       "maximum": 9007199254740991
     },
-    "__schema115": {
+    "__schema117": {
       "type": "object",
       "properties": {
         "scoreThresholds": {
@@ -1478,7 +1498,7 @@
         }
       }
     },
-    "__schema116": {
+    "__schema118": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -1507,17 +1527,20 @@
         },
         "maxConsecutiveFailures": {
           "$ref": "#/definitions/__schema33"
+        },
+        "branch": {
+          "$ref": "#/definitions/__schema35"
         }
       }
     },
-    "__schema117": {
+    "__schema119": {
       "type": "object",
       "properties": {
         "level": {
           "description": "Logging level (trace, debug, info, warn, error, fatal).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema118"
+              "$ref": "#/definitions/__schema120"
             }
           ]
         },
@@ -1525,25 +1548,25 @@
           "description": "Path to log file (logs to stdout if omitted).",
           "allOf": [
             {
-              "$ref": "#/definitions/__schema119"
+              "$ref": "#/definitions/__schema121"
             }
           ]
         }
       }
     },
-    "__schema118": {
-      "type": "string"
-    },
-    "__schema119": {
-      "type": "string"
-    },
     "__schema120": {
-      "type": "number"
+      "type": "string"
     },
     "__schema121": {
-      "type": "number"
+      "type": "string"
     },
     "__schema122": {
+      "type": "number"
+    },
+    "__schema123": {
+      "type": "number"
+    },
+    "__schema124": {
       "type": "number"
     }
   }

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -649,6 +649,7 @@ On shutdown, the watcher:
     "enabled": true,
     "commitThrottleMs": 30000,
     "maxBatchSize": 1000,
+    "branch": "master",
     "commitMessage": {
       "enabled": true,
       "provider": "anthropic",
@@ -672,6 +673,7 @@ On shutdown, the watcher:
 | `enabled` | `boolean` | `false` | Enable git-backed content versioning. |
 | `commitThrottleMs` | `number` | `30000` | Throttle interval (ms) for batching commits (min: 1000). |
 | `maxBatchSize` | `number` | `1000` | Max files per commit batch (min: 1). |
+| `branch` | `string` | `"master"` | Git branch name for VCS operations. Squash retention and startup recovery target this branch. |
 | `commitMessage.enabled` | `boolean` | `true` | Enable AI-generated commit messages. |
 | `commitMessage.provider` | `string` | `"anthropic"` | LLM provider. |
 | `commitMessage.model` | `string` | `"claude-haiku-4-0"` | Model name. |

--- a/packages/service/guides/version-control.md
+++ b/packages/service/guides/version-control.md
@@ -43,6 +43,7 @@ VCS tracking and watcher embedding are independent concerns. Git can track files
     "enabled": true,
     "commitThrottleMs": 30000,
     "maxBatchSize": 1000,
+    "branch": "master",
     "commitMessage": {
       "enabled": true,
       "provider": "anthropic",
@@ -66,6 +67,7 @@ VCS tracking and watcher embedding are independent concerns. Git can track files
 | `enabled` | `boolean` | `false` | Enable VCS tracking globally. |
 | `commitThrottleMs` | `number` | `30000` | Throttle interval in milliseconds for batching commits (min: 1000). Timer starts on first change and does not reset. |
 | `maxBatchSize` | `number` | `1000` | Max files per commit batch (min: 1). Overflow rolls to next cycle. |
+| `branch` | `string` | `"master"` | Git branch name for VCS operations. Squash retention and startup orphan recovery target this branch instead of dynamically detecting the current branch. |
 | `commitMessage` | `object` | See below | AI commit message generation settings. |
 | `commitMessage.enabled` | `boolean` | `true` | Enable AI-generated commit messages. Falls back to template on failure. |
 | `commitMessage.provider` | `string` | `"anthropic"` | LLM provider for commit messages. |
@@ -498,11 +500,19 @@ The cron expression uses standard 5-field format (`minute hour day-of-month mont
 
 ### Squash Mechanism
 
-1. Parse the commit log and compute the retention boundary
-2. Create an orphan branch at the boundary commit
-3. Use `commit-tree` to create a single squashed baseline commit
-4. Cherry-pick all retained commits on top
-5. Force-update the main branch to the new history
+1. **Pause** the commit pipeline (drain any in-flight commits)
+2. Parse the commit log and compute the retention boundary
+3. Create an orphan branch at the boundary commit
+4. Use `commit-tree` to create a single squashed baseline commit
+5. Cherry-pick all retained commits on top
+6. Force-update the **configured branch** (from `vcs.branch`) to the new history
+7. **Resume** the commit pipeline
+
+All git operations during squash have explicit timeouts (30s standard, 120s for cherry-pick, 60s for push) to prevent permanent pipeline freezes from hung git processes.
+
+### Pause/Resume Coordination
+
+Squash pauses the VcsManager commit pipeline before starting. This drains any pending commits, then blocks new commits from executing during the squash. File changes that arrive during the squash are queued in the pending set and committed after resume. The resume always fires (via a `finally` block), even if the squash fails.
 
 ### Force Push After Squash
 
@@ -511,6 +521,24 @@ If a remote is configured, the squashed history is force-pushed. This is accepta
 ### Lock Contention
 
 If `index.lock` is held by another git operation during squash, the squash aborts cleanly and retries on the next cron cycle. No data is lost.
+
+### Startup Orphan Recovery
+
+If the service starts and a VCS root is on an unexpected branch (e.g., a leftover squash orphan branch from a crash), the VcsManager detects this during startup and recovers:
+
+1. Reads the current branch via `git rev-parse --abbrev-ref HEAD`
+2. If it differs from the configured `branch`, force-updates the configured branch to the current HEAD
+3. Checks out the configured branch
+
+Orphan branches are **not deleted** — they serve as a recovery safety net. If recovery fails, the error is logged and the manager continues with the current state.
+
+### "Nothing to Commit" Handling
+
+When the commit pipeline stages files that haven't actually changed (e.g., a file was touched but content is identical), `git commit` fails with "nothing to commit." This is a no-op, not a failure — the circuit breaker counter is not incremented, and files are not re-queued.
+
+### Retry Timer After Failure
+
+When a commit batch fails and files are re-queued, the throttle timer is restarted so the re-queued files are retried automatically. Without this, re-queued files would sit in the pending set indefinitely until a new `fileChanged()` call arrived.
 
 ---
 
@@ -603,6 +631,22 @@ No manual intervention is needed in most cases. If the circuit breaker trips, in
 **Symptom:** VCS features silently disabled. Log contains `git not found` warning.
 
 **Resolution:** Install git and ensure it is on the system `PATH`. Restart the watcher. On Windows, the installer typically adds git to `PATH` automatically. On Linux, install via your package manager (`apt install git`, `yum install git`, etc.).
+
+### Repo on Wrong Branch After Crash
+
+**Symptom:** Log shows `Repo is on unexpected branch — recovering to configured branch` at startup.
+
+**Cause:** The service crashed or was killed during a squash operation, leaving the repo on a temporary orphan branch.
+
+**Automatic recovery:** The VcsManager detects the wrong branch at startup, force-updates the configured branch to the current HEAD, and checks out the configured branch. No manual intervention needed. The orphan branch is preserved as a safety net.
+
+### Git Operations Timing Out
+
+**Symptom:** Log shows timeout errors for git operations.
+
+**Cause:** A git operation (add, commit, push, cherry-pick) took longer than its timeout.
+
+**Resolution:** Standard operations timeout at 30 seconds, cherry-pick at 120 seconds, push at 60 seconds. If timeouts occur regularly, investigate disk I/O, network connectivity (for push), or repository size (for cherry-pick during squash).
 
 ---
 

--- a/packages/service/src/app/index.ts
+++ b/packages/service/src/app/index.ts
@@ -206,7 +206,7 @@ export class JeevesWatcher {
 
     this.server = await this.startApiServer();
 
-    vcsCoordinator.start();
+    await vcsCoordinator.start();
     this.watcher.start();
     this.startConfigWatch();
 

--- a/packages/service/src/vcs/CommitMessageBuilder.ts
+++ b/packages/service/src/vcs/CommitMessageBuilder.ts
@@ -7,7 +7,7 @@ import type pino from 'pino';
 
 import { normalizeError } from '../util/normalizeError';
 import type { CommitMessageGenerator } from './CommitMessageGenerator';
-import { execFileAsync } from './gitExec';
+import { execFileAsync, GIT_TIMEOUT_STANDARD } from './gitExec';
 import type { PendingReversion } from './types';
 
 /**
@@ -117,12 +117,12 @@ export class CommitMessageBuilder {
       const { stdout: stat } = await execFileAsync(
         'git',
         ['diff', '--cached', '--stat'],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
       const { stdout: patch } = await execFileAsync(
         'git',
         ['diff', '--cached'],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
       return `${stat}\n${patch}`;
     } catch {

--- a/packages/service/src/vcs/CommitMessageBuilder.ts
+++ b/packages/service/src/vcs/CommitMessageBuilder.ts
@@ -117,12 +117,12 @@ export class CommitMessageBuilder {
       const { stdout: stat } = await execFileAsync(
         'git',
         ['diff', '--cached', '--stat'],
-        { cwd: this.rootPath },
+        { cwd: this.rootPath, timeout: 30_000 },
       );
       const { stdout: patch } = await execFileAsync(
         'git',
         ['diff', '--cached'],
-        { cwd: this.rootPath },
+        { cwd: this.rootPath, timeout: 30_000 },
       );
       return `${stat}\n${patch}`;
     } catch {

--- a/packages/service/src/vcs/SquashManager.test.ts
+++ b/packages/service/src/vcs/SquashManager.test.ts
@@ -542,6 +542,26 @@ describe('SquashManager.runSquash', () => {
     expect(callOrder).toEqual(['pause', 'resume']);
   }, 30000);
 
+  it('calls resume when pause throws (Bug 3 — Copilot review)', async () => {
+    await createCommit(tempDir, 'file1.txt', 'a');
+
+    const pauseFn = vi.fn(() => Promise.reject(new Error('pause failed')));
+    const resumeFn = vi.fn(() => {});
+
+    const manager = new SquashManager(
+      tempDir,
+      makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
+      silentLogger,
+      { pauseCommits: pauseFn, resumeCommits: resumeFn },
+    );
+
+    const result = await manager.runSquash();
+    expect(result.squashed).toBe(false);
+    expect(result.error).toBe('pause failed');
+    // Resume must still be called to avoid leaving the pipeline stuck
+    expect(resumeFn).toHaveBeenCalledTimes(1);
+  });
+
   it('calls resume even when squash fails (Bug 3)', async () => {
     // Empty repo — no commits to squash but pause/resume should still be called
     const pauseFn = vi.fn(() => Promise.resolve());

--- a/packages/service/src/vcs/SquashManager.test.ts
+++ b/packages/service/src/vcs/SquashManager.test.ts
@@ -153,6 +153,7 @@ describe('SquashManager.calculateRetentionBoundary', () => {
       '/tmp/test',
       makeRetention({ maxAgeDays: 7, maxVersions: 100 }),
       silentLogger,
+      'master',
     );
 
     const now = new Date();
@@ -175,6 +176,7 @@ describe('SquashManager.calculateRetentionBoundary', () => {
       '/tmp/test',
       makeRetention({ maxAgeDays: 365, maxVersions: 2 }),
       silentLogger,
+      'master',
     );
 
     const now = new Date();
@@ -197,6 +199,7 @@ describe('SquashManager.calculateRetentionBoundary', () => {
       '/tmp/test',
       makeRetention({ maxAgeDays: 365, maxVersions: 100 }),
       silentLogger,
+      'master',
     );
 
     const now = new Date();
@@ -264,6 +267,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
+      'master',
     );
 
     const result = await manager.runSquash();
@@ -314,6 +318,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
+      'master',
     );
 
     const result = await manager.runSquash();
@@ -356,6 +361,9 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
+      'master',
+      undefined,
+      undefined,
       remoteUrl,
     );
 
@@ -397,6 +405,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
+      'master',
     );
 
     const result = await manager.runSquash();
@@ -438,6 +447,9 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       logger,
+      'master',
+      undefined,
+      undefined,
       'https://github.com/test/repo.git',
       'tok/en@special',
     );
@@ -458,10 +470,108 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 1, maxVersions: 1 }),
       silentLogger,
+      'master',
     );
 
     const result = await manager.runSquash();
     expect(result.squashed).toBe(false);
     expect(await commitCount(tempDir)).toBe(1);
+  });
+
+  it('uses configured branch name instead of dynamic detection (Bug 1)', async () => {
+    const now = new Date();
+    await createCommit(
+      tempDir,
+      'file1.txt',
+      'a',
+      new Date(now.getTime() - 60 * 86400000).toISOString(),
+    );
+    await createCommit(
+      tempDir,
+      'file2.txt',
+      'b',
+      new Date(now.getTime() - 1 * 86400000).toISOString(),
+    );
+
+    // Rename the default branch to 'main' to verify configured name is used
+    await execFileAsync('git', ['branch', '-M', 'main'], { cwd: tempDir });
+
+    const manager = new SquashManager(
+      tempDir,
+      makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
+      silentLogger,
+      'main', // configured branch
+    );
+
+    const result = await manager.runSquash();
+    expect(result.squashed).toBe(true);
+
+    // Verify we're on the configured branch
+    const { stdout: branchOut } = await execFileAsync(
+      'git',
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      { cwd: tempDir },
+    );
+    expect(branchOut.trim()).toBe('main');
+  }, 30000);
+
+  it('calls pause/resume callbacks around squash operations (Bug 3)', async () => {
+    const now = new Date();
+    await createCommit(
+      tempDir,
+      'file1.txt',
+      'a',
+      new Date(now.getTime() - 60 * 86400000).toISOString(),
+    );
+    await createCommit(
+      tempDir,
+      'file2.txt',
+      'b',
+      new Date(now.getTime() - 1 * 86400000).toISOString(),
+    );
+
+    const callOrder: string[] = [];
+    const pauseFn = vi.fn(() => {
+      callOrder.push('pause');
+      return Promise.resolve();
+    });
+    const resumeFn = vi.fn(() => {
+      callOrder.push('resume');
+    });
+
+    const manager = new SquashManager(
+      tempDir,
+      makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
+      silentLogger,
+      'master',
+      pauseFn,
+      resumeFn,
+    );
+
+    const result = await manager.runSquash();
+    expect(result.squashed).toBe(true);
+    expect(pauseFn).toHaveBeenCalledTimes(1);
+    expect(resumeFn).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['pause', 'resume']);
+  }, 30000);
+
+  it('calls resume even when squash fails (Bug 3)', async () => {
+    // Empty repo — no commits to squash but pause/resume should still be called
+    const pauseFn = vi.fn(() => Promise.resolve());
+    const resumeFn = vi.fn(() => {});
+
+    const manager = new SquashManager(
+      tempDir,
+      makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
+      silentLogger,
+      'master',
+      pauseFn,
+      resumeFn,
+    );
+
+    const result = await manager.runSquash();
+    expect(result.squashed).toBe(false);
+    expect(pauseFn).toHaveBeenCalledTimes(1);
+    expect(resumeFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/service/src/vcs/SquashManager.test.ts
+++ b/packages/service/src/vcs/SquashManager.test.ts
@@ -153,7 +153,6 @@ describe('SquashManager.calculateRetentionBoundary', () => {
       '/tmp/test',
       makeRetention({ maxAgeDays: 7, maxVersions: 100 }),
       silentLogger,
-      'master',
     );
 
     const now = new Date();
@@ -176,7 +175,6 @@ describe('SquashManager.calculateRetentionBoundary', () => {
       '/tmp/test',
       makeRetention({ maxAgeDays: 365, maxVersions: 2 }),
       silentLogger,
-      'master',
     );
 
     const now = new Date();
@@ -199,7 +197,6 @@ describe('SquashManager.calculateRetentionBoundary', () => {
       '/tmp/test',
       makeRetention({ maxAgeDays: 365, maxVersions: 100 }),
       silentLogger,
-      'master',
     );
 
     const now = new Date();
@@ -267,7 +264,6 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'master',
     );
 
     const result = await manager.runSquash();
@@ -318,7 +314,6 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'master',
     );
 
     const result = await manager.runSquash();
@@ -361,10 +356,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'master',
-      undefined,
-      undefined,
-      remoteUrl,
+      { remoteUrl },
     );
 
     const result = await manager.runSquash();
@@ -405,7 +397,6 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'master',
     );
 
     const result = await manager.runSquash();
@@ -447,11 +438,10 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       logger,
-      'master',
-      undefined,
-      undefined,
-      'https://github.com/test/repo.git',
-      'tok/en@special',
+      {
+        remoteUrl: 'https://github.com/test/repo.git',
+        accessToken: 'tok/en@special',
+      },
     );
 
     const result = await manager.runSquash();
@@ -470,7 +460,6 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 1, maxVersions: 1 }),
       silentLogger,
-      'master',
     );
 
     const result = await manager.runSquash();
@@ -500,7 +489,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'main', // configured branch
+      { branch: 'main' },
     );
 
     const result = await manager.runSquash();
@@ -543,9 +532,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'master',
-      pauseFn,
-      resumeFn,
+      { pauseCommits: pauseFn, resumeCommits: resumeFn },
     );
 
     const result = await manager.runSquash();
@@ -564,9 +551,7 @@ describe('SquashManager.runSquash', () => {
       tempDir,
       makeRetention({ maxAgeDays: 30, maxVersions: 100 }),
       silentLogger,
-      'master',
-      pauseFn,
-      resumeFn,
+      { pauseCommits: pauseFn, resumeCommits: resumeFn },
     );
 
     const result = await manager.runSquash();

--- a/packages/service/src/vcs/SquashManager.ts
+++ b/packages/service/src/vcs/SquashManager.ts
@@ -217,6 +217,8 @@ export class SquashManager {
         { root: this.rootPath, err: normalizeError(error) },
         'Failed to pause commit pipeline before squash',
       );
+      // Resume in case pause partially executed (flush succeeded but flag not set)
+      this.resumeCommits?.();
       return { squashed: false, error: normalizeError(error).message };
     }
 

--- a/packages/service/src/vcs/SquashManager.ts
+++ b/packages/service/src/vcs/SquashManager.ts
@@ -111,6 +111,9 @@ export interface CommitInfo {
 export class SquashManager {
   private readonly rootPath: string;
   private readonly retention: VcsRetentionConfig;
+  private readonly branch: string;
+  private readonly pauseCommits: (() => Promise<void>) | undefined;
+  private readonly resumeCommits: (() => void) | undefined;
   private readonly remoteUrl: string | undefined;
   private readonly accessToken: string | undefined;
   private readonly logger: pino.Logger;
@@ -121,12 +124,18 @@ export class SquashManager {
     rootPath: string,
     retention: VcsRetentionConfig,
     logger: pino.Logger,
+    branch = 'master',
+    pauseCommits?: () => Promise<void>,
+    resumeCommits?: () => void,
     remoteUrl?: string,
     accessToken?: string,
   ) {
     this.rootPath = rootPath;
     this.retention = retention;
     this.logger = logger;
+    this.branch = branch;
+    this.pauseCommits = pauseCommits;
+    this.resumeCommits = resumeCommits;
     this.remoteUrl = remoteUrl;
     this.accessToken = accessToken;
   }
@@ -165,6 +174,9 @@ export class SquashManager {
 
   /**
    * Run the squash operation. Exposed publicly for testing.
+   *
+   * Coordinates with VcsManager by calling pause/resume callbacks
+   * to drain and suspend the commit pipeline during the squash.
    */
   async runSquash(): Promise<SquashResult> {
     // Check for index.lock before starting multi-step operation
@@ -179,6 +191,17 @@ export class SquashManager {
       return { squashed: false, error: 'index.lock exists' };
     } catch {
       // No lock — proceed
+    }
+
+    // Bug 3: Pause the commit pipeline before squash
+    try {
+      await this.pauseCommits?.();
+    } catch (error) {
+      this.logger.error(
+        { root: this.rootPath, err: normalizeError(error) },
+        'Failed to pause commit pipeline before squash',
+      );
+      return { squashed: false, error: normalizeError(error).message };
     }
 
     try {
@@ -217,6 +240,9 @@ export class SquashManager {
         'Squash operation failed',
       );
       return { squashed: false, error: message };
+    } finally {
+      // Bug 3: Always resume the commit pipeline
+      this.resumeCommits?.();
     }
   }
 
@@ -228,7 +254,7 @@ export class SquashManager {
       const { stdout } = await execFileAsync(
         'git',
         ['log', '--format=%H %aI', '--reverse'],
-        { cwd: this.rootPath },
+        { cwd: this.rootPath, timeout: 30_000 },
       );
 
       if (!stdout.trim()) return [];
@@ -284,6 +310,7 @@ export class SquashManager {
 
   /**
    * Perform the squash: create orphan with baseline + cherry-pick retained commits.
+   * Uses the configured branch name instead of dynamic detection (Bug 1).
    */
   private async performSquash(
     commits: CommitInfo[],
@@ -292,13 +319,8 @@ export class SquashManager {
     // The commit just before boundary is the last one to squash
     const baselineHash = commits[boundaryIndex - 1].hash;
 
-    // Get the current branch name
-    const { stdout: branchOut } = await execFileAsync(
-      'git',
-      ['rev-parse', '--abbrev-ref', 'HEAD'],
-      { cwd: this.rootPath },
-    );
-    const currentBranch = branchOut.trim();
+    // Bug 1: Use configured branch name, not dynamic detection
+    const targetBranch = this.branch;
 
     const orphanBranch = `__squash_orphan_${String(Date.now())}`;
 
@@ -306,11 +328,13 @@ export class SquashManager {
       // 1. Create orphan branch with the tree state at the baseline commit
       await execFileAsync('git', ['checkout', '--orphan', orphanBranch], {
         cwd: this.rootPath,
+        timeout: 30_000,
       });
 
       // 2. Reset index to the baseline tree (the last squashed commit's tree)
       await execFileAsync('git', ['reset', '--hard', baselineHash], {
         cwd: this.rootPath,
+        timeout: 30_000,
       });
 
       // 3. Create the baseline commit with the same tree
@@ -318,20 +342,21 @@ export class SquashManager {
       const { stdout: treeOut } = await execFileAsync(
         'git',
         ['rev-parse', `${baselineHash}^{tree}`],
-        { cwd: this.rootPath },
+        { cwd: this.rootPath, timeout: 30_000 },
       );
       const treeHash = treeOut.trim();
 
       const { stdout: commitOut } = await execFileAsync(
         'git',
         ['commit-tree', treeHash, '-m', 'historical baseline'],
-        { cwd: this.rootPath },
+        { cwd: this.rootPath, timeout: 30_000 },
       );
       const baselineCommitHash = commitOut.trim();
 
       // 4. Reset orphan branch to this new baseline commit
       await execFileAsync('git', ['reset', '--hard', baselineCommitHash], {
         cwd: this.rootPath,
+        timeout: 30_000,
       });
 
       // 5. Cherry-pick boundary..HEAD (the retained commits)
@@ -341,39 +366,44 @@ export class SquashManager {
       if (commitsToCherry.length > 0) {
         await execFileAsync('git', ['cherry-pick', ...commitsToCherry], {
           cwd: this.rootPath,
+          timeout: 120_000,
         });
       }
 
-      // 6. Force-update the original branch to the orphan
+      // 6. Force-update the configured branch to the orphan
       const { stdout: newHead } = await execFileAsync(
         'git',
         ['rev-parse', 'HEAD'],
-        { cwd: this.rootPath },
+        { cwd: this.rootPath, timeout: 30_000 },
       );
 
       await execFileAsync(
         'git',
-        ['branch', '-f', currentBranch, newHead.trim()],
-        { cwd: this.rootPath },
+        ['branch', '-f', targetBranch, newHead.trim()],
+        { cwd: this.rootPath, timeout: 30_000 },
       );
 
-      // 7. Switch back to original branch
-      await execFileAsync('git', ['checkout', currentBranch], {
+      // 7. Switch back to configured branch
+      await execFileAsync('git', ['checkout', targetBranch], {
         cwd: this.rootPath,
+        timeout: 30_000,
       });
 
       // 8. Delete orphan branch
       await execFileAsync('git', ['branch', '-D', orphanBranch], {
         cwd: this.rootPath,
+        timeout: 30_000,
       });
     } catch (error) {
-      // Attempt cleanup: try to get back to original branch
+      // Attempt cleanup: try to get back to configured branch
       try {
-        await execFileAsync('git', ['checkout', '-f', currentBranch], {
+        await execFileAsync('git', ['checkout', '-f', targetBranch], {
           cwd: this.rootPath,
+          timeout: 30_000,
         });
         await execFileAsync('git', ['branch', '-D', orphanBranch], {
           cwd: this.rootPath,
+          timeout: 30_000,
         });
       } catch {
         // Cleanup failed — log but re-throw original error
@@ -408,6 +438,7 @@ export class SquashManager {
       await execFileAsync('git', ['push', '--force', pushUrl, 'HEAD'], {
         cwd: this.rootPath,
         env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+        timeout: 60_000,
       });
 
       this.logger.info(

--- a/packages/service/src/vcs/SquashManager.ts
+++ b/packages/service/src/vcs/SquashManager.ts
@@ -10,7 +10,13 @@ import type { VcsRetentionConfig } from '@karmaniverous/jeeves-watcher-core';
 import type pino from 'pino';
 
 import { normalizeError } from '../util/normalizeError';
-import { execFileAsync } from './gitExec';
+import {
+  buildAuthenticatedPushUrl,
+  execFileAsync,
+  GIT_TIMEOUT_CHERRY_PICK,
+  GIT_TIMEOUT_PUSH,
+  GIT_TIMEOUT_STANDARD,
+} from './gitExec';
 
 /**
  * Parse a standard 5-field cron expression and check if the current time matches.
@@ -108,6 +114,20 @@ export interface CommitInfo {
  * then cherry-picks retained commits on top. Force-pushes to remote
  * if configured (D13).
  */
+/** Options for SquashManager construction beyond the required params. */
+export interface SquashManagerOptions {
+  /** Git branch name for squash operations. Default: "master". */
+  branch?: string;
+  /** Called before squash to drain and pause the commit pipeline. */
+  pauseCommits?: () => Promise<void>;
+  /** Called after squash to resume the commit pipeline. */
+  resumeCommits?: () => void;
+  /** Remote URL for force-push after squash. */
+  remoteUrl?: string;
+  /** Access token for HTTPS push authentication. */
+  accessToken?: string;
+}
+
 export class SquashManager {
   private readonly rootPath: string;
   private readonly retention: VcsRetentionConfig;
@@ -124,20 +144,16 @@ export class SquashManager {
     rootPath: string,
     retention: VcsRetentionConfig,
     logger: pino.Logger,
-    branch = 'master',
-    pauseCommits?: () => Promise<void>,
-    resumeCommits?: () => void,
-    remoteUrl?: string,
-    accessToken?: string,
+    options: SquashManagerOptions = {},
   ) {
     this.rootPath = rootPath;
     this.retention = retention;
     this.logger = logger;
-    this.branch = branch;
-    this.pauseCommits = pauseCommits;
-    this.resumeCommits = resumeCommits;
-    this.remoteUrl = remoteUrl;
-    this.accessToken = accessToken;
+    this.branch = options.branch ?? 'master';
+    this.pauseCommits = options.pauseCommits;
+    this.resumeCommits = options.resumeCommits;
+    this.remoteUrl = options.remoteUrl;
+    this.accessToken = options.accessToken;
   }
 
   /**
@@ -254,7 +270,7 @@ export class SquashManager {
       const { stdout } = await execFileAsync(
         'git',
         ['log', '--format=%H %aI', '--reverse'],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
 
       if (!stdout.trim()) return [];
@@ -328,13 +344,13 @@ export class SquashManager {
       // 1. Create orphan branch with the tree state at the baseline commit
       await execFileAsync('git', ['checkout', '--orphan', orphanBranch], {
         cwd: this.rootPath,
-        timeout: 30_000,
+        timeout: GIT_TIMEOUT_STANDARD,
       });
 
       // 2. Reset index to the baseline tree (the last squashed commit's tree)
       await execFileAsync('git', ['reset', '--hard', baselineHash], {
         cwd: this.rootPath,
-        timeout: 30_000,
+        timeout: GIT_TIMEOUT_STANDARD,
       });
 
       // 3. Create the baseline commit with the same tree
@@ -342,21 +358,21 @@ export class SquashManager {
       const { stdout: treeOut } = await execFileAsync(
         'git',
         ['rev-parse', `${baselineHash}^{tree}`],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
       const treeHash = treeOut.trim();
 
       const { stdout: commitOut } = await execFileAsync(
         'git',
         ['commit-tree', treeHash, '-m', 'historical baseline'],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
       const baselineCommitHash = commitOut.trim();
 
       // 4. Reset orphan branch to this new baseline commit
       await execFileAsync('git', ['reset', '--hard', baselineCommitHash], {
         cwd: this.rootPath,
-        timeout: 30_000,
+        timeout: GIT_TIMEOUT_STANDARD,
       });
 
       // 5. Cherry-pick boundary..HEAD (the retained commits)
@@ -366,7 +382,7 @@ export class SquashManager {
       if (commitsToCherry.length > 0) {
         await execFileAsync('git', ['cherry-pick', ...commitsToCherry], {
           cwd: this.rootPath,
-          timeout: 120_000,
+          timeout: GIT_TIMEOUT_CHERRY_PICK,
         });
       }
 
@@ -374,36 +390,36 @@ export class SquashManager {
       const { stdout: newHead } = await execFileAsync(
         'git',
         ['rev-parse', 'HEAD'],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
 
       await execFileAsync(
         'git',
         ['branch', '-f', targetBranch, newHead.trim()],
-        { cwd: this.rootPath, timeout: 30_000 },
+        { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
       );
 
       // 7. Switch back to configured branch
       await execFileAsync('git', ['checkout', targetBranch], {
         cwd: this.rootPath,
-        timeout: 30_000,
+        timeout: GIT_TIMEOUT_STANDARD,
       });
 
       // 8. Delete orphan branch
       await execFileAsync('git', ['branch', '-D', orphanBranch], {
         cwd: this.rootPath,
-        timeout: 30_000,
+        timeout: GIT_TIMEOUT_STANDARD,
       });
     } catch (error) {
       // Attempt cleanup: try to get back to configured branch
       try {
         await execFileAsync('git', ['checkout', '-f', targetBranch], {
           cwd: this.rootPath,
-          timeout: 30_000,
+          timeout: GIT_TIMEOUT_STANDARD,
         });
         await execFileAsync('git', ['branch', '-D', orphanBranch], {
           cwd: this.rootPath,
-          timeout: 30_000,
+          timeout: GIT_TIMEOUT_STANDARD,
         });
       } catch {
         // Cleanup failed — log but re-throw original error
@@ -428,17 +444,15 @@ export class SquashManager {
     if (!this.remoteUrl) return;
 
     try {
-      const pushUrl = this.accessToken
-        ? this.remoteUrl.replace(
-            /^https:\/\//,
-            `https://${encodeURIComponent(this.accessToken)}@`,
-          )
-        : this.remoteUrl;
+      const pushUrl = buildAuthenticatedPushUrl(
+        this.remoteUrl,
+        this.accessToken,
+      );
 
       await execFileAsync('git', ['push', '--force', pushUrl, 'HEAD'], {
         cwd: this.rootPath,
         env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-        timeout: 60_000,
+        timeout: GIT_TIMEOUT_PUSH,
       });
 
       this.logger.info(

--- a/packages/service/src/vcs/VcsCoordinator.test.ts
+++ b/packages/service/src/vcs/VcsCoordinator.test.ts
@@ -77,7 +77,7 @@ describe('VcsCoordinator', () => {
   it('routes file changes to the correct root manager', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Write files to both roots
     const fileA = join(resolve(rootA), 'a.txt');
@@ -105,7 +105,7 @@ describe('VcsCoordinator', () => {
   it('ignores files that do not match any root', async () => {
     const config = makeConfig([rootA]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // A file outside all roots — should be silently ignored
     coordinator.onFileChange('/nonexistent/path/file.txt', 'add');
@@ -123,7 +123,7 @@ describe('VcsCoordinator', () => {
     } as unknown as JeevesWatcherConfig;
 
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     const fileA = join(resolve(rootA), 'a.txt');
     await writeFile(fileA, 'content', 'utf8');
@@ -138,7 +138,7 @@ describe('VcsCoordinator', () => {
   it('handles unlink events by staging deletions', async () => {
     const config = makeConfig([rootA]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Create and commit a file first
     const filePath = join(resolve(rootA), 'to-remove.txt');
@@ -234,7 +234,7 @@ describe('VcsCoordinator', () => {
   it('onInitialScanComplete calls endBaseline on all managers', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Call onInitialScanComplete to end baseline on all managers
     await coordinator.onInitialScanComplete();
@@ -257,7 +257,7 @@ describe('VcsCoordinator', () => {
   it('stop flushes all pending changes', async () => {
     const config = makeConfig([rootA, rootB]);
     const coordinator = new VcsCoordinator(config, silentLogger);
-    coordinator.start();
+    await coordinator.start();
 
     // Add files to both roots without flushing
     const fileA = join(resolve(rootA), 'pending-a.txt');

--- a/packages/service/src/vcs/VcsCoordinator.ts
+++ b/packages/service/src/vcs/VcsCoordinator.ts
@@ -99,11 +99,14 @@ export class VcsCoordinator {
 
   /**
    * Start all VcsManager instances.
+   * Runs startup orphan detection/recovery for each root.
    */
-  start(): void {
+  async start(): Promise<void> {
+    const startPromises: Promise<void>[] = [];
     this.managers.forEach((manager) => {
-      manager.start();
+      startPromises.push(manager.start());
     });
+    await Promise.all(startPromises);
     this.logger.info(
       { rootCount: this.managers.size },
       'VcsCoordinator started',

--- a/packages/service/src/vcs/VcsManager.test.ts
+++ b/packages/service/src/vcs/VcsManager.test.ts
@@ -28,6 +28,7 @@ function makeConfig(overrides: Partial<VcsConfig> = {}): VcsConfig {
     maxBatchSize: 1000,
     staleLockThresholdMs: 60000,
     maxConsecutiveFailures: 5,
+    branch: 'master',
     ...overrides,
   };
 }
@@ -72,7 +73,7 @@ describe('VcsManager instance', () => {
   describe('flush', () => {
     it('commits pending files to git', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       const filePath = join(tempDir, 'test.txt');
@@ -100,7 +101,7 @@ describe('VcsManager instance', () => {
       });
 
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const { stdout: before } = await execFileAsync(
         'git',
@@ -119,7 +120,7 @@ describe('VcsManager instance', () => {
 
     it('handles multiple files in a single commit', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       for (let i = 0; i < 5; i++) {
         const filePath = join(tempDir, `file${String(i)}.txt`);
@@ -141,7 +142,7 @@ describe('VcsManager instance', () => {
   describe('handleUnlink', () => {
     it('stages file deletion in pending set', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       // Create and commit a file first
@@ -179,7 +180,7 @@ describe('VcsManager instance', () => {
 
       const config = makeConfig({ commitThrottleMs: 5000 });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      manager.start();
+      await manager.start();
 
       // Mock flush to avoid real git operations with fake timers
       const flushSpy = vi.spyOn(manager, 'flush').mockResolvedValue(undefined);
@@ -209,7 +210,7 @@ describe('VcsManager instance', () => {
         commitThrottleMs: 60000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      manager.start();
+      await manager.start();
 
       for (let i = 0; i < 3; i++) {
         const filePath = join(tempDir, `file${String(i)}.txt`);
@@ -235,7 +236,7 @@ describe('VcsManager instance', () => {
         commitThrottleMs: 1000,
       });
       const manager = new VcsManager(tempDir, config, silentLogger);
-      manager.start();
+      await manager.start();
 
       // Create 3 files — 2 should commit immediately, 1 starts new timer
       for (let i = 0; i < 3; i++) {
@@ -255,7 +256,7 @@ describe('VcsManager instance', () => {
   describe('stop', () => {
     it('flushes pending changes on stop', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       const filePath = join(tempDir, 'stop-test.txt');
@@ -274,7 +275,7 @@ describe('VcsManager instance', () => {
 
     it('ignores fileChanged calls after stop', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const file1 = join(tempDir, 'before-stop.txt');
       await writeFile(file1, 'before', 'utf8');
@@ -306,7 +307,7 @@ describe('VcsManager instance', () => {
       const warnSpy = vi.spyOn(logger, 'warn');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       // Create index.lock to simulate contention
@@ -341,7 +342,7 @@ describe('VcsManager instance', () => {
       const errorSpy = vi.spyOn(logger, 'error');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      manager.start();
+      await manager.start();
 
       // Create index.lock and keep it there
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -365,7 +366,7 @@ describe('VcsManager instance', () => {
       const warnSpy = vi.spyOn(logger, 'warn');
 
       const manager = new VcsManager(tempDir, makeConfig(), logger);
-      manager.start();
+      await manager.start();
 
       // Create index.lock to force failure
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -404,7 +405,7 @@ describe('VcsManager instance', () => {
 
       const config = makeConfig({ staleLockThresholdMs: 5000 });
       const manager = new VcsManager(tempDir, config, logger);
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       // Create a stale lock file with old mtime
@@ -434,7 +435,7 @@ describe('VcsManager instance', () => {
 
       const config = makeConfig({ staleLockThresholdMs: 60000 });
       const manager = new VcsManager(tempDir, config, logger);
-      manager.start();
+      await manager.start();
 
       // Create a fresh lock file (mtime = now)
       const lockPath = join(tempDir, '.git', 'index.lock');
@@ -466,7 +467,7 @@ describe('VcsManager instance', () => {
         staleLockThresholdMs: 600000,
       });
       const manager = new VcsManager(tempDir, config, logger);
-      manager.start();
+      await manager.start();
 
       const lockPath = join(tempDir, '.git', 'index.lock');
       await writeFile(lockPath, '', 'utf8');
@@ -503,7 +504,7 @@ describe('VcsManager instance', () => {
         staleLockThresholdMs: 600000,
       });
       const manager = new VcsManager(tempDir, config, logger);
-      manager.start();
+      await manager.start();
 
       const lockPath = join(tempDir, '.git', 'index.lock');
       await writeFile(lockPath, '', 'utf8');
@@ -536,7 +537,7 @@ describe('VcsManager instance', () => {
         staleLockThresholdMs: 600000,
       });
       const manager = new VcsManager(tempDir, config, logger);
-      manager.start();
+      await manager.start();
 
       const lockPath = join(tempDir, '.git', 'index.lock');
       await writeFile(lockPath, '', 'utf8');
@@ -585,7 +586,7 @@ describe('VcsManager instance', () => {
         maxConsecutiveFailures: 100,
       });
       const manager = new VcsManager(tempDir, config, logger);
-      manager.start();
+      await manager.start();
 
       const lockPath = join(tempDir, '.git', 'index.lock');
       await writeFile(lockPath, '', 'utf8');
@@ -626,7 +627,7 @@ describe('VcsManager instance', () => {
   describe('pendingReversions', () => {
     it('generates revert-prefixed commit message when reversion is pending', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'reverted.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -659,7 +660,7 @@ describe('VcsManager instance', () => {
 
     it('includes other changes count in revert message when mixed', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       // Create initial commit
       const file1 = join(tempDir, 'reverted.txt');
@@ -698,7 +699,7 @@ describe('VcsManager instance', () => {
 
     it('clears pending reversions after commit', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const file1 = join(tempDir, 'first.txt');
       await writeFile(file1, 'content', 'utf8');
@@ -747,7 +748,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       const filePath = join(tempDir, 'ai-test.txt');
@@ -779,7 +780,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       const filePath = join(tempDir, 'fallback.txt');
@@ -813,7 +814,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       const filePath = join(tempDir, 'error-fallback.txt');
@@ -847,7 +848,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
       manager.endBaseline();
 
       const filePath = join(tempDir, 'reverted-ai.txt');
@@ -893,7 +894,7 @@ describe('VcsManager instance', () => {
         silentLogger,
         generator,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'revert-fallback.txt');
       await writeFile(filePath, 'original', 'utf8');
@@ -925,7 +926,7 @@ describe('VcsManager instance', () => {
   describe('endBaseline', () => {
     it('uses baseline message before endBaseline is called', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
       // isBaseline starts true — no endBaseline call
 
       const filePath = join(tempDir, 'baseline-file.txt');
@@ -946,7 +947,7 @@ describe('VcsManager instance', () => {
 
     it('switches to normal messages after endBaseline is called', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'pre-scan.txt');
       await writeFile(filePath, 'initial', 'utf8');
@@ -969,7 +970,7 @@ describe('VcsManager instance', () => {
 
     it('uses normal message for second commit after endBaseline', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'first.txt');
       await writeFile(filePath, 'first', 'utf8');
@@ -1024,7 +1025,7 @@ describe('VcsManager instance', () => {
         undefined,
         remoteUrl,
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'push-test.txt');
       await writeFile(filePath, 'push content', 'utf8');
@@ -1045,7 +1046,7 @@ describe('VcsManager instance', () => {
 
     it('does nothing when no remote is configured', async () => {
       const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'no-remote.txt');
       await writeFile(filePath, 'no remote', 'utf8');
@@ -1068,7 +1069,7 @@ describe('VcsManager instance', () => {
         undefined,
         'https://invalid.example.com/nonexistent/repo.git',
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'push-fail.txt');
       await writeFile(filePath, 'will fail push', 'utf8');
@@ -1094,7 +1095,7 @@ describe('VcsManager instance', () => {
         'https://github.com/test/repo.git',
         'tok/en@special',
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'encode-test.txt');
       await writeFile(filePath, 'content', 'utf8');
@@ -1121,7 +1122,7 @@ describe('VcsManager instance', () => {
         remoteUrl, // use plain path so push actually works
         'fake-token',
       );
-      manager.start();
+      await manager.start();
 
       const filePath = join(tempDir, 'token-push.txt');
       await writeFile(filePath, 'token push content', 'utf8');
@@ -1138,5 +1139,135 @@ describe('VcsManager instance', () => {
       expect(stdout).toContain('1 files');
       expect(manager.lastPushTime).not.toBeNull();
     });
+  });
+
+  describe('retry timer after failure (Bug 2)', () => {
+    it('re-queued files commit on next flush without needing fileChanged', async () => {
+      const config = makeConfig({
+        staleLockThresholdMs: 600000,
+      });
+      const logger = pino({ level: 'silent' });
+      const manager = new VcsManager(tempDir, config, logger);
+      await manager.start();
+      manager.endBaseline();
+
+      // Create index.lock to force failure
+      const lockPath = join(tempDir, '.git', 'index.lock');
+      await writeFile(lockPath, '', 'utf8');
+
+      const filePath = join(tempDir, 'retry-timer.txt');
+      await writeFile(filePath, 'content', 'utf8');
+      manager.fileChanged(filePath);
+
+      // Flush triggers commitBatch which fails and re-queues
+      await manager.flush();
+
+      // Remove lock so next attempt succeeds
+      await rm(lockPath, { force: true });
+
+      // Without Bug 2 fix, re-queued files would sit forever.
+      // With the fix, resetThrottle() was called, so flush() finds them.
+      await manager.flush();
+
+      // The re-queued file should have committed successfully
+      expect(await commitCount(tempDir)).toBe(1);
+    }, 30000);
+  });
+
+  describe('nothing to commit exclusion (Bug 5)', () => {
+    it('does not increment circuit breaker on nothing-to-commit error', async () => {
+      const logger = pino({ level: 'silent' });
+      const infoSpy = vi.spyOn(logger, 'info');
+
+      const config = makeConfig({ maxConsecutiveFailures: 2 });
+      const manager = new VcsManager(tempDir, config, logger);
+      await manager.start();
+      manager.endBaseline();
+
+      // Create and commit a file, then try to commit the same file without changes
+      const filePath = join(tempDir, 'no-change.txt');
+      await writeFile(filePath, 'content', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: tempDir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], {
+        cwd: tempDir,
+      });
+
+      // File hasn't changed but we report it — git commit will say "nothing to commit"
+      manager.fileChanged(filePath);
+      await manager.flush();
+
+      // Should log info about nothing to commit, not error
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ root: tempDir }),
+        expect.stringContaining('nothing to commit'),
+      );
+
+      // Circuit breaker should NOT have been tripped
+      // Verify by adding a real change that should succeed
+      const file2 = join(tempDir, 'real-change.txt');
+      await writeFile(file2, 'new content', 'utf8');
+      manager.fileChanged(file2);
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(2);
+    }, 30000);
+  });
+
+  describe('pause/resume (Bug 3)', () => {
+    it('pause drains pending commits then blocks new commits', async () => {
+      const manager = new VcsManager(tempDir, makeConfig(), silentLogger);
+      await manager.start();
+      manager.endBaseline();
+
+      // Add a file and pause — pause calls flush internally
+      const file1 = join(tempDir, 'pre-pause.txt');
+      await writeFile(file1, 'content', 'utf8');
+      manager.fileChanged(file1);
+
+      await manager.pause();
+
+      // The file should have been committed during pause's flush
+      expect(await commitCount(tempDir)).toBe(1);
+
+      // While paused, add another file and flush — should NOT commit
+      const file2 = join(tempDir, 'during-pause.txt');
+      await writeFile(file2, 'content', 'utf8');
+      manager.fileChanged(file2);
+      await manager.flush();
+
+      // Still 1 commit — the paused file was re-queued
+      expect(await commitCount(tempDir)).toBe(1);
+
+      // Resume and flush — now the file should commit
+      manager.resume();
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(2);
+    });
+
+    it('resume commits pending files accumulated during pause', async () => {
+      const config = makeConfig({ commitThrottleMs: 100 });
+      const manager = new VcsManager(tempDir, config, silentLogger);
+      await manager.start();
+      manager.endBaseline();
+
+      await manager.pause();
+
+      // Add file while paused
+      const filePath = join(tempDir, 'resume-timer.txt');
+      await writeFile(filePath, 'content', 'utf8');
+      manager.fileChanged(filePath);
+
+      // Resume should eventually commit via throttle timer
+      manager.resume();
+
+      // Wait for throttle to fire and commit
+      await new Promise((r) => {
+        setTimeout(r, 300);
+      });
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(1);
+    }, 10000);
   });
 });

--- a/packages/service/src/vcs/VcsManager.test.ts
+++ b/packages/service/src/vcs/VcsManager.test.ts
@@ -14,6 +14,7 @@ import pino from 'pino';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CommitMessageGenerator } from './CommitMessageGenerator';
+import * as vcsBootstrap from './vcsBootstrap';
 import { initRepo } from './vcsBootstrap';
 import { VcsManager } from './VcsManager';
 
@@ -1138,6 +1139,37 @@ describe('VcsManager instance', () => {
       );
       expect(stdout).toContain('1 files');
       expect(manager.lastPushTime).not.toBeNull();
+    });
+  });
+
+  describe('start orphan recovery resilience (Bug 6)', () => {
+    it('continues startup when orphan recovery throws', async () => {
+      const logger = pino({ level: 'silent' });
+      const errorSpy = vi.spyOn(logger, 'error');
+
+      // Make detectAndRecoverOrphanBranch throw
+      vi.spyOn(
+        vcsBootstrap,
+        'detectAndRecoverOrphanBranch',
+      ).mockRejectedValueOnce(new Error('git not available'));
+
+      const manager = new VcsManager(tempDir, makeConfig(), logger);
+      await manager.start();
+
+      // Should have logged the error
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ root: tempDir }),
+        'Orphan branch recovery failed — continuing with current state',
+      );
+
+      // Manager should still be functional
+      manager.endBaseline();
+      const filePath = join(tempDir, 'after-recovery-fail.txt');
+      await writeFile(filePath, 'content', 'utf8');
+      manager.fileChanged(filePath);
+      await manager.flush();
+
+      expect(await commitCount(tempDir)).toBe(1);
     });
   });
 

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -13,7 +13,12 @@ import { normalizeError } from '../util/normalizeError';
 import { retry } from '../util/retry';
 import { CommitMessageBuilder } from './CommitMessageBuilder';
 import type { CommitMessageGenerator } from './CommitMessageGenerator';
-import { execFileAsync, gitAddViaStdin } from './gitExec';
+import {
+  execFileAsync,
+  getExecErrorFields,
+  GIT_TIMEOUT_STANDARD,
+  gitAddViaStdin,
+} from './gitExec';
 import { SquashManager } from './SquashManager';
 import type { PendingReversion, PushError } from './types';
 import { detectAndRecoverOrphanBranch } from './vcsBootstrap';
@@ -75,15 +80,17 @@ export class VcsManager {
         rootPath,
         config.retention,
         logger,
-        config.branch,
-        () => {
-          return this.pause();
+        {
+          branch: config.branch,
+          pauseCommits: () => {
+            return this.pause();
+          },
+          resumeCommits: () => {
+            this.resume();
+          },
+          remoteUrl,
+          accessToken,
         },
-        () => {
-          this.resume();
-        },
-        remoteUrl,
-        accessToken,
       );
     }
   }
@@ -303,12 +310,7 @@ export class VcsManager {
    * Git outputs this message to stdout (not stderr) on exit code 1.
    */
   private isNothingToCommitError(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    const message = error.message || '';
-    const stderr =
-      'stderr' in error ? String((error as { stderr: unknown }).stderr) : '';
-    const stdout =
-      'stdout' in error ? String((error as { stdout: unknown }).stdout) : '';
+    const { message, stderr, stdout } = getExecErrorFields(error);
     return (
       message.includes('nothing to commit') ||
       stderr.includes('nothing to commit') ||
@@ -354,7 +356,7 @@ export class VcsManager {
 
       await retry(
         async (attempt) => {
-          await gitAddViaStdin(files, this.rootPath, 30_000);
+          await gitAddViaStdin(files, this.rootPath, GIT_TIMEOUT_STANDARD);
 
           // Build message after staging so getStagedDiff can see the changes.
           // Skip AI for baselines and retries — use template directly.
@@ -374,13 +376,13 @@ export class VcsManager {
           this.pendingReversions.length = 0;
           await execFileAsync('git', ['commit', '-m', message], {
             cwd: this.rootPath,
-            timeout: 30_000,
+            timeout: GIT_TIMEOUT_STANDARD,
           });
 
           const { stdout: hashOut } = await execFileAsync(
             'git',
             ['rev-parse', '--short', 'HEAD'],
-            { cwd: this.rootPath, timeout: 30_000 },
+            { cwd: this.rootPath, timeout: GIT_TIMEOUT_STANDARD },
           );
           const hash = hashOut.trim();
           this.logger.info(

--- a/packages/service/src/vcs/VcsManager.ts
+++ b/packages/service/src/vcs/VcsManager.ts
@@ -16,6 +16,7 @@ import type { CommitMessageGenerator } from './CommitMessageGenerator';
 import { execFileAsync, gitAddViaStdin } from './gitExec';
 import { SquashManager } from './SquashManager';
 import type { PendingReversion, PushError } from './types';
+import { detectAndRecoverOrphanBranch } from './vcsBootstrap';
 import { pushToRemote } from './vcsPush';
 
 export type { PendingReversion, PushError };
@@ -45,6 +46,7 @@ export class VcsManager {
   private commitInFlight: Promise<void> = Promise.resolve();
   private consecutiveCommitFailures = 0;
   private started = false;
+  private paused = false;
   private isBaseline = true;
   private _lastPushTime: string | null = null;
 
@@ -73,6 +75,13 @@ export class VcsManager {
         rootPath,
         config.retention,
         logger,
+        config.branch,
+        () => {
+          return this.pause();
+        },
+        () => {
+          this.resume();
+        },
         remoteUrl,
         accessToken,
       );
@@ -91,10 +100,24 @@ export class VcsManager {
    * Begin accepting file changes. Sets the manager to started state and
    * starts the squash manager if configured.
    *
+   * Performs startup orphan detection/recovery before starting the squash
+   * manager, ensuring the repo is on the configured branch.
+   *
    * Baseline mode (commit prefix `"baseline:"`) remains active until
    * {@link endBaseline} is called by the coordinator after the initial scan.
    */
-  start(): void {
+  async start(): Promise<void> {
+    // Bug 6: Detect and recover from orphan branches before normal operations
+    const branch = this.config.branch;
+    try {
+      await detectAndRecoverOrphanBranch(this.rootPath, branch, this.logger);
+    } catch (error) {
+      this.logger.error(
+        { root: this.rootPath, err: normalizeError(error) },
+        'Orphan branch recovery failed — continuing with current state',
+      );
+    }
+
     this.started = true;
     this.squashManager?.start();
     this.logger.info({ root: this.rootPath }, 'VcsManager started');
@@ -161,6 +184,30 @@ export class VcsManager {
   handleUnlink(filePath: string): void {
     if (!this.started) return;
     this.fileChanged(filePath);
+  }
+
+  /**
+   * Pause the commit pipeline. Drains pending commits via flush(), then
+   * sets a flag that makes commitBatch queue instead of execute.
+   * Used by SquashManager to coordinate squash operations.
+   */
+  async pause(): Promise<void> {
+    await this.flush();
+    this.paused = true;
+    this.logger.debug({ root: this.rootPath }, 'VcsManager paused');
+  }
+
+  /**
+   * Resume the commit pipeline after a pause.
+   * Re-enables normal commit operations and starts a throttle timer
+   * if there are pending files that accumulated during the pause.
+   */
+  resume(): void {
+    this.paused = false;
+    this.logger.debug({ root: this.rootPath }, 'VcsManager resumed');
+    if (this.pending.size > 0) {
+      this.resetThrottle();
+    }
   }
 
   /**
@@ -252,11 +299,41 @@ export class VcsManager {
   }
 
   /**
+   * Check whether a git error represents a "nothing to commit" state.
+   * Git outputs this message to stdout (not stderr) on exit code 1.
+   */
+  private isNothingToCommitError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const message = error.message || '';
+    const stderr =
+      'stderr' in error ? String((error as { stderr: unknown }).stderr) : '';
+    const stdout =
+      'stdout' in error ? String((error as { stdout: unknown }).stdout) : '';
+    return (
+      message.includes('nothing to commit') ||
+      stderr.includes('nothing to commit') ||
+      stdout.includes('nothing to commit')
+    );
+  }
+
+  /**
    * Commit a batch of files to the git repo with index.lock retry,
-   * stale lock detection, circuit breaker, and re-queue cap.
+   * stale lock detection, circuit breaker, pause support, and re-queue cap.
    */
   private async commitBatch(files: string[]): Promise<void> {
     if (files.length === 0) return;
+
+    // Pause support: re-queue files without counting as failure
+    if (this.paused) {
+      for (const f of files) {
+        this.pending.add(f);
+      }
+      this.logger.debug(
+        { root: this.rootPath, fileCount: files.length },
+        'VcsManager paused — files re-queued',
+      );
+      return;
+    }
 
     // Circuit breaker: skip if too many consecutive failures
     if (this.consecutiveCommitFailures >= this.config.maxConsecutiveFailures) {
@@ -277,7 +354,7 @@ export class VcsManager {
 
       await retry(
         async (attempt) => {
-          await gitAddViaStdin(files, this.rootPath);
+          await gitAddViaStdin(files, this.rootPath, 30_000);
 
           // Build message after staging so getStagedDiff can see the changes.
           // Skip AI for baselines and retries — use template directly.
@@ -297,12 +374,13 @@ export class VcsManager {
           this.pendingReversions.length = 0;
           await execFileAsync('git', ['commit', '-m', message], {
             cwd: this.rootPath,
+            timeout: 30_000,
           });
 
           const { stdout: hashOut } = await execFileAsync(
             'git',
             ['rev-parse', '--short', 'HEAD'],
-            { cwd: this.rootPath },
+            { cwd: this.rootPath, timeout: 30_000 },
           );
           const hash = hashOut.trim();
           this.logger.info(
@@ -335,6 +413,15 @@ export class VcsManager {
       // Success — reset circuit breaker
       this.consecutiveCommitFailures = 0;
     } catch (error) {
+      // Bug 5: "nothing to commit" is a no-op, not a failure
+      if (this.isNothingToCommitError(error)) {
+        this.logger.info(
+          { root: this.rootPath, fileCount: files.length },
+          'VCS commit skipped — nothing to commit',
+        );
+        return;
+      }
+
       this.consecutiveCommitFailures++;
 
       // Re-queue cap: only re-queue up to maxBatchSize files
@@ -361,6 +448,9 @@ export class VcsManager {
         { root: this.rootPath, err: normalizeError(error) },
         'VCS commit failed',
       );
+
+      // Bug 2: Restart throttle timer so re-queued files get retried
+      this.resetThrottle();
     }
   }
 }

--- a/packages/service/src/vcs/gitExec.test.ts
+++ b/packages/service/src/vcs/gitExec.test.ts
@@ -11,7 +11,13 @@ import { promisify } from 'node:util';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { findRootForPath, gitAddViaStdin, isIndexLockError } from './gitExec';
+import {
+  buildAuthenticatedPushUrl,
+  findRootForPath,
+  getExecErrorFields,
+  gitAddViaStdin,
+  isIndexLockError,
+} from './gitExec';
 import { initRepo } from './vcsBootstrap';
 
 const execFileAsync = promisify(execFile);
@@ -147,6 +153,97 @@ describe('gitAddViaStdin', () => {
       { cwd: tempDir },
     );
     expect(stdout.trim()).toBe('file with spaces.txt');
+  });
+});
+
+describe('getExecErrorFields', () => {
+  it('extracts message, stderr, and stdout from an ExecFileException', () => {
+    const err = new Error('Command failed: git commit');
+    (err as unknown as Record<string, unknown>).stderr =
+      'fatal: nothing to commit';
+    (err as unknown as Record<string, unknown>).stdout =
+      'On branch master\nnothing to commit';
+
+    const fields = getExecErrorFields(err);
+    expect(fields.message).toBe('Command failed: git commit');
+    expect(fields.stderr).toBe('fatal: nothing to commit');
+    expect(fields.stdout).toBe('On branch master\nnothing to commit');
+  });
+
+  it('returns empty stderr/stdout when not present on Error', () => {
+    const err = new Error('plain error');
+    const fields = getExecErrorFields(err);
+    expect(fields.message).toBe('plain error');
+    expect(fields.stderr).toBe('');
+    expect(fields.stdout).toBe('');
+  });
+
+  it('handles non-Error values by stringifying', () => {
+    expect(getExecErrorFields('string error')).toEqual({
+      message: 'string error',
+      stderr: '',
+      stdout: '',
+    });
+    expect(getExecErrorFields(42)).toEqual({
+      message: '42',
+      stderr: '',
+      stdout: '',
+    });
+    expect(getExecErrorFields(null)).toEqual({
+      message: 'null',
+      stderr: '',
+      stdout: '',
+    });
+  });
+
+  it('ignores non-string stderr/stdout properties', () => {
+    const err = new Error('typed error');
+    (err as unknown as Record<string, unknown>).stderr = 123;
+    (err as unknown as Record<string, unknown>).stdout = { obj: true };
+
+    const fields = getExecErrorFields(err);
+    expect(fields.stderr).toBe('');
+    expect(fields.stdout).toBe('');
+  });
+});
+
+describe('buildAuthenticatedPushUrl', () => {
+  it('returns URL unchanged when no token provided', () => {
+    const url = 'https://github.com/owner/repo.git';
+    expect(buildAuthenticatedPushUrl(url)).toBe(url);
+  });
+
+  it('returns URL unchanged when token is undefined', () => {
+    const url = 'https://github.com/owner/repo.git';
+    expect(buildAuthenticatedPushUrl(url, undefined)).toBe(url);
+  });
+
+  it('injects token into HTTPS URL', () => {
+    expect(
+      buildAuthenticatedPushUrl(
+        'https://github.com/owner/repo.git',
+        'mytoken123',
+      ),
+    ).toBe('https://mytoken123@github.com/owner/repo.git');
+  });
+
+  it('URL-encodes special characters in token', () => {
+    expect(
+      buildAuthenticatedPushUrl(
+        'https://github.com/owner/repo.git',
+        'tok/en@special',
+      ),
+    ).toBe('https://tok%2Fen%40special@github.com/owner/repo.git');
+  });
+
+  it('does not modify non-HTTPS URLs', () => {
+    const sshUrl = 'git@github.com:owner/repo.git';
+    expect(buildAuthenticatedPushUrl(sshUrl, 'mytoken')).toBe(sshUrl);
+  });
+
+  it('does not modify file:// URLs', () => {
+    const fileUrl = 'file:///tmp/bare-repo';
+    expect(buildAuthenticatedPushUrl(fileUrl, 'mytoken')).toBe(fileUrl);
   });
 });
 

--- a/packages/service/src/vcs/gitExec.ts
+++ b/packages/service/src/vcs/gitExec.ts
@@ -20,25 +20,42 @@ export const execFileAsync = promisify(execFile);
  *
  * @param files - Absolute paths of files to stage.
  * @param cwd   - Repository root (working directory for git).
+ * @param timeoutMs - Kill the child process after this many milliseconds. Default: 30000.
  */
-export function gitAddViaStdin(files: string[], cwd: string): Promise<void> {
+export function gitAddViaStdin(
+  files: string[],
+  cwd: string,
+  timeoutMs = 30_000,
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    let timedOut = false;
     const child = execFile(
       'git',
       ['add', '--pathspec-from-file=-', '--pathspec-file-nul'],
       { cwd },
       (error: Error | null) => {
+        clearTimeout(timer);
+        if (timedOut) return;
         if (error) reject(error);
         else resolve();
       },
     );
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+      reject(new Error(`git add timed out after ${String(timeoutMs)}ms`));
+    }, timeoutMs);
+
     if (!child.stdin) {
+      clearTimeout(timer);
       reject(new Error('Failed to open stdin for git add'));
       return;
     }
     // Suppress EPIPE — expected if git exits before we finish writing
     child.stdin.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code !== 'EPIPE') {
+        clearTimeout(timer);
         reject(err);
       }
     });

--- a/packages/service/src/vcs/gitExec.ts
+++ b/packages/service/src/vcs/gitExec.ts
@@ -9,6 +9,53 @@ import { promisify } from 'node:util';
 /** Promisified execFile for git commands. */
 export const execFileAsync = promisify(execFile);
 
+/** Standard timeout (ms) for most git operations. */
+export const GIT_TIMEOUT_STANDARD = 30_000;
+
+/** Extended timeout (ms) for cherry-pick operations. */
+export const GIT_TIMEOUT_CHERRY_PICK = 120_000;
+
+/** Timeout (ms) for push operations. */
+export const GIT_TIMEOUT_PUSH = 60_000;
+
+/**
+ * Extract string fields from a child-process error.
+ * Node's execFile wraps failures in an Error with `stderr`, `stdout`, and
+ * `code` properties that aren't part of the Error type.
+ */
+export function getExecErrorFields(error: unknown): {
+  message: string;
+  stderr: string;
+  stdout: string;
+} {
+  if (!(error instanceof Error)) {
+    return { message: String(error), stderr: '', stdout: '' };
+  }
+  const rec = error as unknown as Record<string, unknown>;
+  const stderr = typeof rec['stderr'] === 'string' ? rec['stderr'] : '';
+  const stdout = typeof rec['stdout'] === 'string' ? rec['stdout'] : '';
+  return { message: error.message || '', stderr, stdout };
+}
+
+/**
+ * Build an authenticated push URL by injecting a token into an HTTPS remote.
+ * Non-HTTPS URLs are returned as-is.
+ *
+ * @param remoteUrl - The remote repository URL.
+ * @param accessToken - Optional access token to inject.
+ * @returns The URL with the token injected if applicable.
+ */
+export function buildAuthenticatedPushUrl(
+  remoteUrl: string,
+  accessToken?: string,
+): string {
+  if (!accessToken) return remoteUrl;
+  return remoteUrl.replace(
+    /^https:\/\//,
+    `https://${encodeURIComponent(accessToken)}@`,
+  );
+}
+
 /**
  * Stage files via stdin to avoid ENAMETOOLONG on Windows.
  *
@@ -107,12 +154,11 @@ export function findRootForPath(
 
 /**
  * Check whether an error is caused by index.lock contention.
+ * Only considers Error instances — plain strings/nulls return false.
  */
 export function isIndexLockError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  const message = error.message || '';
-  const stderr =
-    'stderr' in error ? String((error as { stderr: unknown }).stderr) : '';
+  const { message, stderr } = getExecErrorFields(error);
   return (
     message.includes('index.lock') ||
     stderr.includes('index.lock') ||

--- a/packages/service/src/vcs/index.ts
+++ b/packages/service/src/vcs/index.ts
@@ -6,8 +6,13 @@
 export { CommitMessageBuilder } from './CommitMessageBuilder.js';
 export { CommitMessageGenerator } from './CommitMessageGenerator.js';
 export {
+  buildAuthenticatedPushUrl,
   execFileAsync,
   findRootForPath,
+  getExecErrorFields,
+  GIT_TIMEOUT_CHERRY_PICK,
+  GIT_TIMEOUT_PUSH,
+  GIT_TIMEOUT_STANDARD,
   gitAddViaStdin,
   isIndexLockError,
   normalizePathCase,
@@ -22,6 +27,7 @@ export {
   type CommitInfo,
   cronMatchesNow,
   SquashManager,
+  type SquashManagerOptions,
   type SquashResult,
 } from './SquashManager.js';
 export { type PendingReversion, type PushError } from './types.js';

--- a/packages/service/src/vcs/index.ts
+++ b/packages/service/src/vcs/index.ts
@@ -30,6 +30,7 @@ export {
   ALWAYS_GITIGNORE_ENTRIES,
   checkGitAvailable,
   configureRepoIdentity,
+  detectAndRecoverOrphanBranch,
   ensureGitignore,
   initRepo,
 } from './vcsBootstrap.js';

--- a/packages/service/src/vcs/vcsBootstrap.test.ts
+++ b/packages/service/src/vcs/vcsBootstrap.test.ts
@@ -3,19 +3,23 @@
  * Tests for bootstrap utilities: checkGitAvailable, initRepo, ensureGitignore.
  */
 
-import { access, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import pino from 'pino';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { execFileAsync } from './gitExec';
 import {
   checkGitAvailable,
   configureRepoIdentity,
+  detectAndRecoverOrphanBranch,
   ensureGitignore,
   initRepo,
 } from './vcsBootstrap';
+
+const silentLogger = pino({ level: 'silent' });
 
 // ─── checkGitAvailable ───
 
@@ -159,5 +163,131 @@ describe('ensureGitignore', () => {
     const content = await readFile(join(tempDir, '.gitignore'), 'utf8');
     expect(content).toContain('*.log');
     expect(content).toContain('tmp/');
+  });
+});
+
+// ─── detectAndRecoverOrphanBranch (Bug 6) ───
+
+describe('detectAndRecoverOrphanBranch', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vcs-orphan-'));
+    await initRepo(tempDir);
+    await execFileAsync('git', ['config', 'user.email', 'test@test.com'], {
+      cwd: tempDir,
+    });
+    await execFileAsync('git', ['config', 'user.name', 'Test'], {
+      cwd: tempDir,
+    });
+    // Create initial commit on master
+    await writeFile(join(tempDir, 'init.txt'), 'init', 'utf8');
+    await execFileAsync('git', ['add', '.'], { cwd: tempDir });
+    await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: tempDir });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('is a no-op when already on the expected branch', async () => {
+    await detectAndRecoverOrphanBranch(tempDir, 'master', silentLogger);
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      { cwd: tempDir },
+    );
+    expect(stdout.trim()).toBe('master');
+  });
+
+  it('recovers to expected branch when on an orphan', async () => {
+    const logger = pino({ level: 'silent' });
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const infoSpy = vi.spyOn(logger, 'info');
+
+    // Simulate orphan state: create an orphan branch and add a commit
+    await execFileAsync(
+      'git',
+      ['checkout', '--orphan', '__squash_orphan_123'],
+      { cwd: tempDir },
+    );
+    await writeFile(join(tempDir, 'orphan.txt'), 'orphan content', 'utf8');
+    await execFileAsync('git', ['add', '.'], { cwd: tempDir });
+    await execFileAsync('git', ['commit', '-m', 'orphan commit'], {
+      cwd: tempDir,
+    });
+
+    // Get the orphan HEAD hash
+    const { stdout: orphanHead } = await execFileAsync(
+      'git',
+      ['rev-parse', 'HEAD'],
+      { cwd: tempDir },
+    );
+
+    await detectAndRecoverOrphanBranch(tempDir, 'master', logger);
+
+    // Should now be on master
+    const { stdout: branch } = await execFileAsync(
+      'git',
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      { cwd: tempDir },
+    );
+    expect(branch.trim()).toBe('master');
+
+    // Master should point to the orphan HEAD (the latest work)
+    const { stdout: masterHead } = await execFileAsync(
+      'git',
+      ['rev-parse', 'HEAD'],
+      { cwd: tempDir },
+    );
+    expect(masterHead.trim()).toBe(orphanHead.trim());
+
+    // Should have logged warning and info
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentBranch: '__squash_orphan_123',
+        expectedBranch: 'master',
+      }),
+      expect.stringContaining('unexpected branch'),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recoveredFrom: '__squash_orphan_123',
+        expectedBranch: 'master',
+      }),
+      expect.stringContaining('recovery complete'),
+    );
+  });
+
+  it('does NOT delete orphan branches', async () => {
+    // Create orphan branch
+    await execFileAsync(
+      'git',
+      ['checkout', '--orphan', '__squash_orphan_456'],
+      { cwd: tempDir },
+    );
+    await writeFile(join(tempDir, 'orphan2.txt'), 'content', 'utf8');
+    await execFileAsync('git', ['add', '.'], { cwd: tempDir });
+    await execFileAsync('git', ['commit', '-m', 'orphan'], { cwd: tempDir });
+
+    await detectAndRecoverOrphanBranch(tempDir, 'master', silentLogger);
+
+    // Orphan branch should still exist
+    const { stdout: branches } = await execFileAsync(
+      'git',
+      ['branch', '--list'],
+      { cwd: tempDir },
+    );
+    expect(branches).toContain('__squash_orphan_456');
+  });
+
+  it('is a no-op for non-git directories', async () => {
+    const nonGitDir = await mkdtemp(join(tmpdir(), 'vcs-nongit-'));
+    // Should not throw
+    await expect(
+      detectAndRecoverOrphanBranch(nonGitDir, 'master', silentLogger),
+    ).resolves.toBeUndefined();
+    await rm(nonGitDir, { recursive: true, force: true });
   });
 });

--- a/packages/service/src/vcs/vcsBootstrap.ts
+++ b/packages/service/src/vcs/vcsBootstrap.ts
@@ -6,6 +6,8 @@
 import { access, appendFile, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import type pino from 'pino';
+
 import { execFileAsync } from './gitExec';
 
 /** Always-on .gitignore entries for VCS-managed watch roots. */
@@ -65,6 +67,70 @@ export async function configureRepoIdentity(
   await execFileAsync('git', ['config', '--local', 'user.email', email], {
     cwd: rootPath,
   });
+}
+
+/**
+ * Detect and recover from orphan branch state on startup.
+ *
+ * If the repo is on an unexpected branch (e.g. a leftover squash orphan),
+ * force-updates the expected branch to the current HEAD and checks it out.
+ * Orphan branches are NOT deleted — they serve as a recovery safety net.
+ *
+ * @param rootPath - Directory of the git repository.
+ * @param expectedBranch - The configured branch name (e.g. "master").
+ * @param logger - Logger instance for warnings and info.
+ */
+export async function detectAndRecoverOrphanBranch(
+  rootPath: string,
+  expectedBranch: string,
+  logger: pino.Logger,
+): Promise<void> {
+  const gitDir = join(rootPath, '.git');
+  try {
+    await access(gitDir);
+  } catch {
+    // Not a git repo — nothing to detect
+    return;
+  }
+
+  const { stdout: branchOut } = await execFileAsync(
+    'git',
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    { cwd: rootPath, timeout: 30_000 },
+  );
+  const currentBranch = branchOut.trim();
+
+  if (currentBranch === expectedBranch) return;
+
+  logger.warn(
+    { root: rootPath, currentBranch, expectedBranch },
+    'Repo is on unexpected branch — recovering to configured branch',
+  );
+
+  // Get current HEAD
+  const { stdout: headOut } = await execFileAsync(
+    'git',
+    ['rev-parse', 'HEAD'],
+    { cwd: rootPath, timeout: 30_000 },
+  );
+  const headHash = headOut.trim();
+
+  // Force-update the expected branch to current HEAD
+  await execFileAsync('git', ['branch', '-f', expectedBranch, headHash], {
+    cwd: rootPath,
+    timeout: 30_000,
+  });
+
+  // Checkout the expected branch
+  await execFileAsync('git', ['checkout', expectedBranch], {
+    cwd: rootPath,
+    timeout: 30_000,
+  });
+
+  logger.info(
+    { root: rootPath, recoveredFrom: currentBranch, expectedBranch, headHash },
+    'Orphan branch recovery complete — now on configured branch',
+  );
 }
 
 /**

--- a/packages/service/src/vcs/vcsBootstrap.ts
+++ b/packages/service/src/vcs/vcsBootstrap.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 
 import type pino from 'pino';
 
-import { execFileAsync } from './gitExec';
+import { execFileAsync, GIT_TIMEOUT_STANDARD } from './gitExec';
 
 /** Always-on .gitignore entries for VCS-managed watch roots. */
 export const ALWAYS_GITIGNORE_ENTRIES = [
@@ -96,7 +96,7 @@ export async function detectAndRecoverOrphanBranch(
   const { stdout: branchOut } = await execFileAsync(
     'git',
     ['rev-parse', '--abbrev-ref', 'HEAD'],
-    { cwd: rootPath, timeout: 30_000 },
+    { cwd: rootPath, timeout: GIT_TIMEOUT_STANDARD },
   );
   const currentBranch = branchOut.trim();
 
@@ -111,20 +111,20 @@ export async function detectAndRecoverOrphanBranch(
   const { stdout: headOut } = await execFileAsync(
     'git',
     ['rev-parse', 'HEAD'],
-    { cwd: rootPath, timeout: 30_000 },
+    { cwd: rootPath, timeout: GIT_TIMEOUT_STANDARD },
   );
   const headHash = headOut.trim();
 
   // Force-update the expected branch to current HEAD
   await execFileAsync('git', ['branch', '-f', expectedBranch, headHash], {
     cwd: rootPath,
-    timeout: 30_000,
+    timeout: GIT_TIMEOUT_STANDARD,
   });
 
   // Checkout the expected branch
   await execFileAsync('git', ['checkout', expectedBranch], {
     cwd: rootPath,
-    timeout: 30_000,
+    timeout: GIT_TIMEOUT_STANDARD,
   });
 
   logger.info(

--- a/packages/service/src/vcs/vcsPush.ts
+++ b/packages/service/src/vcs/vcsPush.ts
@@ -43,6 +43,7 @@ export async function pushToRemote(
     await execFileAsync('git', ['push', pushUrl, 'HEAD'], {
       cwd: rootPath,
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      timeout: 60_000,
     });
 
     const timestamp = new Date().toISOString();

--- a/packages/service/src/vcs/vcsPush.ts
+++ b/packages/service/src/vcs/vcsPush.ts
@@ -6,7 +6,11 @@
 import type pino from 'pino';
 
 import { normalizeError } from '../util/normalizeError';
-import { execFileAsync } from './gitExec';
+import {
+  buildAuthenticatedPushUrl,
+  execFileAsync,
+  GIT_TIMEOUT_PUSH,
+} from './gitExec';
 import type { PushError } from './types';
 
 /**
@@ -32,18 +36,12 @@ export async function pushToRemote(
   if (!remoteUrl) return undefined;
 
   try {
-    // Build the authenticated URL if a token is available
-    const pushUrl = accessToken
-      ? remoteUrl.replace(
-          /^https:\/\//,
-          `https://${encodeURIComponent(accessToken)}@`,
-        )
-      : remoteUrl;
+    const pushUrl = buildAuthenticatedPushUrl(remoteUrl, accessToken);
 
     await execFileAsync('git', ['push', pushUrl, 'HEAD'], {
       cwd: rootPath,
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-      timeout: 60_000,
+      timeout: GIT_TIMEOUT_PUSH,
     });
 
     const timestamp = new Date().toISOString();


### PR DESCRIPTION
Fix 6 interacting bugs in the VCS subsystem (SquashManager + VcsManager):

### Bug 1: Squash orphan leak (branch identity)
SquashManager now uses the configured `branch` name (new VcsConfig field, default `"master"`) instead of dynamically reading `git branch --show-current`. Prevents operating on leftover orphan branches.

### Bug 2: No retry timer after commit failure
Calls `resetThrottle()` after re-queuing files in the `commitBatch` catch block. Re-queued files no longer sit indefinitely waiting for external `fileChanged()` calls.

### Bug 3: Pause/resume coordination
VcsManager exposes `pause()` and `resume()`. SquashManager calls `pause()` before squash (drains pending commits) and `resume()` after (in a `finally` block). Prevents `commitBatch` from running against transient repo state during squash.

### Bug 4: Git operation timeouts
All `execFileAsync` and `gitAddViaStdin` calls now have explicit timeouts: 30s for standard operations, 120s for cherry-pick, 60s for push. Prevents permanent `commitInFlight` freezes from hung git processes.

### Bug 5: "Nothing to commit" exclusion
Detects `nothing to commit` in git error output (stdout/stderr/message) and skips circuit breaker increment. This is a no-op, not a failure.

### Bug 6: Startup orphan detection
New `detectAndRecoverOrphanBranch()` runs during `VcsManager.start()`. If the repo is on an unexpected branch, force-updates the configured branch to current HEAD and checks it out. Does NOT delete orphan branches (recovery safety net).

Fixes #230
